### PR TITLE
Fix meld logic when handling oneof and optional values.

### DIFF
--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -95,6 +95,15 @@ var tests = []testData{
 		},
 		"testdata/meld/meld_optional_required_2.pb.txt",
 	},
+	{
+		// meld(oneof(T1, T2), oneof(T3, T4)) => oneof(T1, T2, T3, T4)
+		"meld additive oneof",
+		[]string{
+			"testdata/meld/meld_additive_oneof_1.pb.txt",
+			"testdata/meld/meld_additive_oneof_2.pb.txt",
+		},
+		"testdata/meld/meld_additive_oneof_expected.pb.txt",
+	},
 }
 
 func TestMeldWithFormats(t *testing.T) {

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -96,7 +96,7 @@ var tests = []testData{
 		"testdata/meld/meld_optional_required_2.pb.txt",
 	},
 	{
-		// meld(oneof(T1, T2), oneof(T3, T4)) => oneof(T1, T2, T3, T4)
+		// meld(oneof(T1, T2), oneof(T1, T3)) => oneof(T1, T2, T3)
 		"meld additive oneof",
 		[]string{
 			"testdata/meld/meld_additive_oneof_1.pb.txt",

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -86,6 +86,15 @@ var tests = []testData{
 		},
 		"testdata/meld/meld_suppress_none_conflict_expected.pb.txt",
 	},
+	{
+		// Test meld(T, optional<T>) => optional<T>
+		"meld optional and non-optional versions of the same type",
+		[]string{
+			"testdata/meld/meld_optional_required_1.pb.txt",
+			"testdata/meld/meld_optional_required_2.pb.txt",
+		},
+		"testdata/meld/meld_optional_required_2.pb.txt",
+	},
 }
 
 func TestMeldWithFormats(t *testing.T) {

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -104,6 +104,15 @@ var tests = []testData{
 		},
 		"testdata/meld/meld_additive_oneof_expected.pb.txt",
 	},
+	{
+		// meld(oneof(T1, T2), T3) => oneof(T1, T2, T3)
+		"meld additive oneof",
+		[]string{
+			"testdata/meld/meld_oneof_with_primitive_1.pb.txt",
+			"testdata/meld/meld_oneof_with_primitive_2.pb.txt",
+		},
+		"testdata/meld/meld_oneof_with_primitive_expected.pb.txt",
+	},
 }
 
 func TestMeldWithFormats(t *testing.T) {

--- a/spec_util/testdata/meld/meld_additive_oneof_1.pb.txt
+++ b/spec_util/testdata/meld/meld_additive_oneof_1.pb.txt
@@ -1,0 +1,66 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"6JrDs8poHbU="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key:"H--6VaA31gw="
+                value: {
+                  primitive: {
+                    string_value: {
+                      value:"2020-01"
+                    }
+                    formats: {
+                      key:"ISOYearMonth"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "naAThnYPT5A="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {
+                            value: "file_1"
+                          }
+                          formats: {
+                            key: "ISOYearMonth"
+                            value: true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_additive_oneof_2.pb.txt
+++ b/spec_util/testdata/meld/meld_additive_oneof_2.pb.txt
@@ -1,0 +1,45 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"6JrDs8poHbU="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key:"PGYGe9fHTG4="
+                value: {
+                  primitive: {
+                    int32_value: {
+                      value:20200101
+                    }
+                    formats: {
+                      key:"ISOYearMonthDay"
+                      value:true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_additive_oneof_2.pb.txt
+++ b/spec_util/testdata/meld/meld_additive_oneof_2.pb.txt
@@ -10,6 +10,20 @@ method: {
           value: {
             oneof: {
               options: {
+                key:"H--6VaA31gw="
+                value: {
+                  primitive: {
+                    string_value: {
+                      value:"2020-01"
+                    }
+                    formats: {
+                      key:"ISOYearMonth"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
                 key:"PGYGe9fHTG4="
                 value: {
                   primitive: {

--- a/spec_util/testdata/meld/meld_additive_oneof_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_additive_oneof_expected.pb.txt
@@ -1,0 +1,80 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"h5NvuS7asm0="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key:"H--6VaA31gw="
+                value: {
+                  primitive: {
+                    string_value: {
+                      value:"2020-01"
+                    }
+                    formats: {
+                      key:"ISOYearMonth"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key:"PGYGe9fHTG4="
+                value: {
+                  primitive: {
+                    int32_value: {
+                      value:20200101
+                    }
+                    formats: {
+                      key:"ISOYearMonthDay"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "naAThnYPT5A="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {
+                            value: "file_1"
+                          }
+                          formats: {
+                            key: "ISOYearMonth"
+                            value: true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_oneof_with_primitive_1.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_primitive_1.pb.txt
@@ -1,0 +1,66 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"6JrDs8poHbU="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key:"H--6VaA31gw="
+                value: {
+                  primitive: {
+                    string_value: {
+                      value:"2020-01"
+                    }
+                    formats: {
+                      key:"ISOYearMonth"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "naAThnYPT5A="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {
+                            value: "file_1"
+                          }
+                          formats: {
+                            key: "ISOYearMonth"
+                            value: true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_oneof_with_primitive_2.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_primitive_2.pb.txt
@@ -1,0 +1,38 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"6JrDs8poHbU="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            primitive: {
+              int32_value: {
+                value:20200101
+              }
+              formats: {
+                key:"ISOYearMonthDay"
+                value:true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_oneof_with_primitive_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_primitive_expected.pb.txt
@@ -1,0 +1,80 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"h5NvuS7asm0="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key:"H--6VaA31gw="
+                value: {
+                  primitive: {
+                    string_value: {
+                      value:"2020-01"
+                    }
+                    formats: {
+                      key:"ISOYearMonth"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key:"PGYGe9fHTG4="
+                value: {
+                  primitive: {
+                    int32_value: {
+                      value:20200101
+                    }
+                    formats: {
+                      key:"ISOYearMonthDay"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "naAThnYPT5A="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {
+                            value: "file_1"
+                          }
+                          formats: {
+                            key: "ISOYearMonth"
+                            value: true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_optional_required_1.pb.txt
+++ b/spec_util/testdata/meld/meld_optional_required_1.pb.txt
@@ -1,0 +1,36 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file"
+      host: "www.akibox.com"
+    }
+  }
+  responses: {
+    key: "naAThnYPT5A="
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {
+                value: "foo"
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_optional_required_2.pb.txt
+++ b/spec_util/testdata/meld/meld_optional_required_2.pb.txt
@@ -1,0 +1,40 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file"
+      host: "www.akibox.com"
+    }
+  }
+  responses: {
+    key: "t62RbxwCDgQ="
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            optional: {
+              data: {
+                primitive: {
+                  string_value: {
+                    value: "foo"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes:
- Collapse optional and non-optional values if identical 
    ````
    meld(optional<T>, T) => optional<T>
    ````

- Make all oneofs additive, not just for Akita injected conflicts
    ````
    meld(oneof<T1, T2>, oneof<T1, T3>) => oneof<T1, T2, T3>
    meld(oneof<T1, T2>, T3) => oneof<T1, T2, T3>
    ````