### PR TITLE
Fix meld logic for optional non-primitives.

### DIFF
--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -113,6 +113,22 @@ var tests = []testData{
 		},
 		"testdata/meld/meld_oneof_with_primitive_expected.pb.txt",
 	},
+	{
+		"meld struct",
+		[]string{
+			"testdata/meld/meld_struct_1.pb.txt",
+			"testdata/meld/meld_struct_2.pb.txt",
+		},
+		"testdata/meld/meld_struct_2.pb.txt",
+	},
+	{
+		"meld list",
+		[]string{
+			"testdata/meld/meld_list_1.pb.txt",
+			"testdata/meld/meld_list_2.pb.txt",
+		},
+		"testdata/meld/meld_list_2.pb.txt",
+	},
 }
 
 func TestMeldWithFormats(t *testing.T) {

--- a/spec_util/testdata/meld/meld_list_1.pb.txt
+++ b/spec_util/testdata/meld/meld_list_1.pb.txt
@@ -1,0 +1,46 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file"
+      host: "www.akibox.com"
+    }
+  }
+  responses: {
+    key: "naAThnYPT5A="
+    value: {
+      list: {
+        elems: {
+          struct: {
+            fields: {
+              key: "name"
+              value: {
+                primitive: {
+                  string_value: {}
+                }
+              }
+            }
+            fields: {
+              key: "number"
+              value: {
+                primitive: {
+                  int64_value: {}
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_list_2.pb.txt
+++ b/spec_util/testdata/meld/meld_list_2.pb.txt
@@ -1,0 +1,58 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file"
+      host: "www.akibox.com"
+    }
+  }
+  responses: {
+    key: "SUIa2yc6jx4="
+    value: {
+      optional: {
+        data: {
+          list: {
+            elems: {
+              optional: {
+                data: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {}
+                        }
+                      }
+                    }
+                    fields: {
+                      key: "number"
+                      value: {
+                        optional: {
+                          data: {
+                            primitive: {
+                              int64_value: {}
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_struct_1.pb.txt
+++ b/spec_util/testdata/meld/meld_struct_1.pb.txt
@@ -1,0 +1,42 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file"
+      host: "www.akibox.com"
+    }
+  }
+  responses: {
+    key: "naAThnYPT5A="
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {}
+            }
+          }
+        }
+        fields: {
+          key: "number"
+          value: {
+            primitive: {
+              int64_value: {}
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_struct_2.pb.txt
+++ b/spec_util/testdata/meld/meld_struct_2.pb.txt
@@ -1,0 +1,50 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file"
+      host: "www.akibox.com"
+    }
+  }
+  responses: {
+    key: "g5TWRIpUUEY="
+    value: {
+      optional: {
+        data: {
+          struct: {
+            fields: {
+              key: "name"
+              value: {
+                primitive: {
+                  string_value: {}
+                }
+              }
+            }
+            fields: {
+              key: "number"
+              value: {
+                optional: {
+                  data: {
+                    primitive: {
+                      int64_value: {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
In the scenario `meld(T, optional<T>)`, the change in #1 only handled
the case where `T` is a primitive. This PR fixes the logic to handle
complex types such as `struct` and `lists`.