### PR TITLE
Ensure examples are stable

### DIFF
--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -104,9 +104,9 @@ func isNone(d *pb.Data) bool {
 }
 
 func mergeExampleValues(dst, src *pb.Data) {
-	// Take at most one example each from src and dst.
 	examples := make(map[string]*pb.ExampleValue, 2)
 
+	// Get up to two examples each from src and dst.
 	exampleMaps := []map[string]*pb.ExampleValue{dst.ExampleValues, src.ExampleValues}
 	for _, exampleMap := range exampleMaps {
 		keys := make([]string, 0, len(exampleMap))
@@ -117,11 +117,25 @@ func mergeExampleValues(dst, src *pb.Data) {
 		// Sort keys to ensure a stable selection.
 		sort.Strings(keys)
 
-		if len(keys) == 0 {
+		for i, k := range keys {
+			examples[k] = exampleMap[k]
+			if i == 1 {
+				break
+			}
+		}
+	}
+
+	// Keep the two smallest examples, delete any others.
+	keys := make([]string, 0, len(examples))
+	for k := range examples {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		if i < 2 {
 			continue
 		}
-
-		examples[keys[0]] = exampleMap[keys[0]]
+		delete(examples, k)
 	}
 
 	dst.ExampleValues = examples

--- a/spec_util/testdata/meld/meld_examples_big_3.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_big_3.pb.txt
@@ -24,11 +24,11 @@ method: {
         }
       }
       example_values: {
-        key: "f4"
+        key: "f1"
         value: {}
       }
       example_values: {
-        key: "f1"
+        key: "f2"
         value: {}
       }
     }


### PR DESCRIPTION
This fixes a bug where examples chosen for path parameters depended on the
order in which witnesses were processed.