### PR TITLE
BUGFIX: Postorder visitor traversal

### DIFF
--- a/visitors/go_ast/ast_visitor_test.go
+++ b/visitors/go_ast/ast_visitor_test.go
@@ -12,17 +12,21 @@ type Counter struct {
 	count int
 }
 
-func countInt(c visitors.Context, v interface{}, x interface{}) (visitors.Context, bool) {
+func countInt(c visitors.Context, v interface{}, x interface{}) bool {
 	counter := v.(*Counter)
 	if _, ok := x.(int); ok {
 		counter.count++
 	}
-	return c, true
+	return true
+}
+
+func extendContext(c visitors.Context, v interface{}, x interface{}) visitors.Context {
+	return c
 }
 
 func TestApply(t *testing.T) {
 	counter := new(Counter)
-	vm := visitors.NewVisitorManager(visitors.NewContext(), counter, countInt)
+	vm := visitors.NewVisitorManager(visitors.NewContext(), counter, countInt, extendContext)
 	d := []int{1, 2, 3}
 	Apply(PREORDER, vm, d)
 	assert.Equal(t, 3, counter.count)

--- a/visitors/http_rest/http_rest_spec_visitor_test.go
+++ b/visitors/http_rest/http_rest_spec_visitor_test.go
@@ -60,7 +60,17 @@ var expectedPaths = []string{
 	"localhost:9000.GET./api/0/projects/.Response.200.Body.JSON.0.color.Data.api_spec.String",
 }
 
-func TestTraversal(t *testing.T) {
+func TestPreorderTraversal(t *testing.T) {
+	spec := test.LoadAPISpecFromFileOrDie("../testdata/sentry_ir_spec.pb.txt")
+
+	var visitor MyVisitor
+	Apply(go_ast.PREORDER, &visitor, spec)
+	sort.Strings(expectedPaths)
+	sort.Strings(visitor.actualPaths)
+	assert.Equal(t, expectedPaths, visitor.actualPaths)
+}
+
+func TestPostorderTraversal(t *testing.T) {
 	spec := test.LoadAPISpecFromFileOrDie("../testdata/sentry_ir_spec.pb.txt")
 
 	var visitor MyVisitor


### PR DESCRIPTION
The postorder visitor traversal was previously unused and untested.  This PR
fixes two bugs and adds a postorder test:

 - `keepGoing` is now initialized to true in the go_ast visitor application.
   When initialized to false, it prevents the postorder visitor from being
   applied.
 - Context extension is now separated from visitor application.  This allows
   the context to be extended before visiting children in a postorder
   traversal.