### PR TITLE
Extend spec summary to count methods by term

### DIFF
--- a/spec_summary/schema.go
+++ b/spec_summary/schema.go
@@ -3,13 +3,13 @@ package spec_summary
 // Summarizes a spec along different dimensions that can be used to filter for
 // parts of the spec.
 type Summary struct {
-	Authentications map[string]struct{} `json:"authentications"`
-	HTTPMethods     map[string]struct{} `json:"http_methods"`
-	Paths           map[string]struct{} `json:"paths"`
-	Params          map[string]struct{} `json:"params"`
-	Properties      map[string]struct{} `json:"properties"`
-	ResponseCodes   map[int32]struct{}  `json:"response_codes"`
-	DataFormats     map[string]struct{} `json:"data_formats"`
-	DataKinds       map[string]struct{} `json:"data_kinds"`
-	DataTypes       map[string]struct{} `json:"data_types"`
+	Authentications map[string]int `json:"authentications"`
+	HTTPMethods     map[string]int `json:"http_methods"`
+	Paths           map[string]int `json:"paths"`
+	Params          map[string]int `json:"params"`
+	Properties      map[string]int `json:"properties"`
+	ResponseCodes   map[string]int `json:"response_codes"`
+	DataFormats     map[string]int `json:"data_formats"`
+	DataKinds       map[string]int `json:"data_kinds"`
+	DataTypes       map[string]int `json:"data_types"`
 }

--- a/spec_summary/summarize_test.go
+++ b/spec_summary/summarize_test.go
@@ -11,30 +11,33 @@ import (
 
 func TestSummarize(t *testing.T) {
 	expected := &Summary{
-		Authentications: map[string]struct{}{
-			"BASIC": struct{}{},
+		Authentications: map[string]int{
+			"BASIC": 1,
 		},
-		HTTPMethods: map[string]struct{}{
-			"POST": struct{}{},
+		HTTPMethods: map[string]int{
+			"POST": 1,
 		},
-		Paths: map[string]struct{}{
-			"/v1/projects/{arg3}": struct{}{},
+		Paths: map[string]int{
+			"/v1/projects/{arg3}": 1,
 		},
-		Params: map[string]struct{}{
-			"X-My-Header": struct{}{},
+		Params: map[string]int{
+			"X-My-Header": 1,
 		},
-		Properties: map[string]struct{}{
-			"top-level-prop":       struct{}{},
-			"my-special-prop":      struct{}{},
-			"other-top-level-prop": struct{}{},
+		Properties: map[string]int{
+			"top-level-prop":       1,
+			"my-special-prop":      1,
+			"other-top-level-prop": 1,
 		},
-		ResponseCodes: map[int32]struct{}{
-			200: struct{}{},
+		ResponseCodes: map[string]int{
+			"200": 1,
 		},
-		DataFormats: map[string]struct{}{
-			"rfc3339": struct{}{},
+		DataFormats: map[string]int{
+			"rfc3339": 1,
 		},
-		DataKinds: map[string]struct{}{},
+		DataKinds: map[string]int{},
+		DataTypes: map[string]int{
+			"string": 1,
+		},
 	}
 
 	m1 := test.LoadMethodFromFileOrDie("testdata/method1.pb.txt")

--- a/spec_summary/testdata/method1.pb.txt
+++ b/spec_summary/testdata/method1.pb.txt
@@ -45,6 +45,9 @@ responses: {
         key: "other-top-level-prop"
         value: {
           primitive: {
+            string_value: {
+              type: {}
+            }
             formats: {
               key: "rfc3339"
               value: true


### PR DESCRIPTION
Count the number of methods that contain each term in the summary, e.g. the number of methods with `200` responses, `uuid` data formats, etc.