### PR TITLE
Improve spec summarization

### DIFF
--- a/spec_summary/summarize_test.go
+++ b/spec_summary/summarize_test.go
@@ -43,3 +43,29 @@ func TestSummarize(t *testing.T) {
 	m1 := test.LoadMethodFromFileOrDie("testdata/method1.pb.txt")
 	assert.Equal(t, expected, Summarize(&pb.APISpec{Methods: []*pb.Method{m1}}))
 }
+
+func TestIntersect(t *testing.T) {
+	m1 := test.LoadMethodFromFileOrDie("testdata/method1.pb.txt")
+	m2 := test.LoadMethodFromFileOrDie("testdata/method1.pb.txt")
+
+	setM1 := make(map[*pb.Method]struct{})
+	setM1[m1] = struct{}{}
+
+	setM2 := make(map[*pb.Method]struct{})
+	setM2[m2] = struct{}{}
+
+	setM12 := make(map[*pb.Method]struct{})
+	setM12[m1] = struct{}{}
+	setM12[m2] = struct{}{}
+
+	emptyset := make(map[*pb.Method]struct{})
+
+	assert.Equal(t, emptyset, intersect([]map[*pb.Method]struct{}{setM1, setM2}))
+	assert.Equal(t, emptyset, intersect([]map[*pb.Method]struct{}{emptyset, setM2}))
+	assert.Equal(t, emptyset, intersect([]map[*pb.Method]struct{}{setM1, emptyset}))
+	assert.Equal(t, setM1, intersect([]map[*pb.Method]struct{}{setM1, setM12}))
+	assert.Equal(t, setM1, intersect([]map[*pb.Method]struct{}{setM12, setM1}))
+	assert.Equal(t, setM2, intersect([]map[*pb.Method]struct{}{setM2, setM12}))
+	assert.Equal(t, setM2, intersect([]map[*pb.Method]struct{}{setM12, setM2}))
+	assert.Equal(t, setM12, intersect([]map[*pb.Method]struct{}{setM12, setM12}))
+}


### PR DESCRIPTION
Spec summarization now produces a count of the number of methods of each
property with respect to filters that have been applied.

For example, suppose filters were `{ response_codes: [404] }`.  If the summary
included `HTTPMethods: {"GET": 2}`, it would mean that there are two GET
methods with 404 response codes.