### PR TITLE
Update martian version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,5 @@ require (
 
 replace (
 	github.com/google/gopacket v1.1.18 => github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293
-	github.com/google/martian/v3 v3.0.1 => github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2
+	github.com/google/martian/v3 v3.0.1 => github.com/akitasoftware/martian/v3 v3.0.1-0.20210408175823-8159a63604a0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1z
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
+github.com/akitasoftware/martian/v3 v3.0.1-0.20210408175823-8159a63604a0 h1:I6dMrqlMXbXKpCQUCXKif6eT2FbG9GiXtGTUgBAJHlQ=
+github.com/akitasoftware/martian/v3 v3.0.1-0.20210408175823-8159a63604a0/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba h1:sAv1pLJk8VU9q8CddBocaftsZnb2ppbBEQSN6H5O3kg=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba/go.mod h1:otNn0Cq1YGR1daOez6qwaCaF9tzRk1YkIsxF+6faKNE=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=


### PR DESCRIPTION
This is the same change as https://github.com/akitasoftware/akita-cli/pull/10; it feels wrong to have to make it both places? 

Maybe cutting a release on martian would be the way to go.
