### PR TITLE
Add support for "akita://service" URIs

### DIFF
--- a/akiuri/akiuri.go
+++ b/akiuri/akiuri.go
@@ -1,5 +1,12 @@
 package akiuri
 
+// There are three kinds of URIs supported here:
+//  * akita://serviceName
+//      For these, the ObjectType will be nil and the ObjectName will be empty.
+//  * akita://serviceName:objectType
+//      For these, the ObjectName will be empty.
+//  * akita://serviceName:objectType:objectName
+
 import (
 	"fmt"
 	"strings"
@@ -12,19 +19,26 @@ const (
 type ObjectType int
 
 const (
-	UNKNOWN_TYPE ObjectType = iota
-	SPEC
-	TRACE // aka learn session
+	SPEC  ObjectType = iota
+	TRACE            // aka learn session
 )
 
-func stringToObjectType(s string) ObjectType {
+func (o ObjectType) Ptr() *ObjectType {
+	return &o
+}
+
+func (o1 *ObjectType) Is(o2 ObjectType) bool {
+	return o1 != nil && *o1 == o2
+}
+
+func stringToObjectType(s string) (*ObjectType, error) {
 	switch s {
 	case "spec":
-		return SPEC
+		return SPEC.Ptr(), nil
 	case "trace":
-		return TRACE
+		return TRACE.Ptr(), nil
 	}
-	return UNKNOWN_TYPE
+	return nil, fmt.Errorf("%q is an unknown object type", s)
 }
 
 func (o ObjectType) String() string {
@@ -41,15 +55,25 @@ func (o ObjectType) String() string {
 type URI struct {
 	ServiceName string
 	ObjectName  string
-	ObjectType  ObjectType
+	ObjectType  *ObjectType
 }
 
 func (u URI) String() string {
-	objectPart := ""
-	if u.ObjectName != "" {
-		objectPart = fmt.Sprintf(":%s", u.ObjectName)
+	var sb strings.Builder
+	sb.WriteString(Scheme)
+	sb.WriteString(u.ServiceName)
+
+	if u.ObjectType != nil {
+		sb.WriteString(":")
+		sb.WriteString(u.ObjectType.String())
+
+		if u.ObjectName != "" {
+			sb.WriteString(":")
+			sb.WriteString(u.ObjectName)
+		}
 	}
-	return fmt.Sprintf(Scheme+"%s:%s%s", u.ServiceName, u.ObjectType, objectPart)
+
+	return sb.String()
 }
 
 func (u URI) MarshalText() ([]byte, error) {
@@ -63,13 +87,17 @@ func (u *URI) UnmarshalText(data []byte) error {
 	}
 
 	parts := strings.Split(text[len(Scheme):], ":")
-	if !(2 <= len(parts) && len(parts) <= 3) {
-		return fmt.Errorf("%q does not have 2 or 3 parts", text)
+	if len(parts) > 3 {
+		return fmt.Errorf("%q has more than 3 parts", text)
 	}
 
-	objT := stringToObjectType(parts[1])
-	if objT == UNKNOWN_TYPE {
-		return fmt.Errorf("%q is an unknown object type", parts[1])
+	var objT *ObjectType = nil
+	if len(parts) > 1 {
+		objType, err := stringToObjectType(parts[1])
+		if err != nil {
+			return err
+		}
+		objT = objType
 	}
 
 	u.ServiceName = parts[0]

--- a/akiuri/akiuri.go
+++ b/akiuri/akiuri.go
@@ -27,9 +27,21 @@ func (o ObjectType) Ptr() *ObjectType {
 	return &o
 }
 
+// Inspection methods *********************************************************
+
 func (o1 *ObjectType) Is(o2 ObjectType) bool {
 	return o1 != nil && *o1 == o2
 }
+
+func (o *ObjectType) IsSpec() bool {
+	return o.Is(SPEC)
+}
+
+func (o *ObjectType) IsTrace() bool {
+	return o.Is(TRACE)
+}
+
+// ****************************************************************************
 
 func stringToObjectType(s string) (*ObjectType, error) {
 	switch s {

--- a/akiuri/akiuri_test.go
+++ b/akiuri/akiuri_test.go
@@ -6,23 +6,52 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParse(t *testing.T) {
-	expected := URI{
-		ServiceName: "my_service",
-		ObjectName:  "foobar",
-		ObjectType:  SPEC,
+func TestParseUnparse(t *testing.T) {
+	tests := []struct {
+		string
+		URI
+	}{
+		{"akita://my_service:spec:foobar",
+			URI{
+				ServiceName: "my_service",
+				ObjectName:  "foobar",
+				ObjectType:  SPEC.Ptr(),
+			}},
+		{"akita://my_service:trace:foobar",
+			URI{
+				ServiceName: "my_service",
+				ObjectName:  "foobar",
+				ObjectType:  TRACE.Ptr(),
+			}},
+		{"akita://my_service:spec",
+			URI{
+				ServiceName: "my_service",
+				ObjectName:  "",
+				ObjectType:  SPEC.Ptr(),
+			}},
+		{"akita://my_service:trace",
+			URI{
+				ServiceName: "my_service",
+				ObjectName:  "",
+				ObjectType:  TRACE.Ptr(),
+			}},
+		{"akita://my_service",
+			URI{
+				ServiceName: "my_service",
+				ObjectName:  "",
+				ObjectType:  nil,
+			}},
 	}
 
-	u, err := Parse("akita://my_service:spec:foobar")
-	assert.NoError(t, err)
-	assert.Equal(t, expected, u)
-}
+	for _, test := range tests {
+		t.Run("Parse "+test.string, func(t *testing.T) {
+			u, err := Parse(test.string)
+			assert.NoError(t, err)
+			assert.Equal(t, test.URI, u)
+		})
 
-func TestString(t *testing.T) {
-	u := URI{
-		ServiceName: "my_service",
-		ObjectName:  "foobar",
-		ObjectType:  SPEC,
+		t.Run("Unparse "+test.string, func(t *testing.T) {
+			assert.Equal(t, test.string, test.URI.String())
+		})
 	}
-	assert.Equal(t, "akita://my_service:spec:foobar", u.String())
 }


### PR DESCRIPTION
This changes the representation of Akita URIs: the `ObjectType` component is now a pointer and is `nil` when the object type is not given. Also removed the `UNKNOWN_TYPE` object type, which should not have been externally visible.