### PR TITLE
Remove processing_latency from protobuf hash

### DIFF
--- a/pbhash/pbhash.go
+++ b/pbhash/pbhash.go
@@ -12,6 +12,9 @@ var (
 		protohash.BasicHashFunction(protohash.XXHASH64),
 		// Example values can fluctuate between runs, so we ignore them.
 		protohash.IgnoreFieldName("example_values"),
+		// Do not include latency when deduplicating by hash
+		// for a learning sessions
+		protohash.IgnoreFieldName("processing_latency"),
 	)
 )
 


### PR DESCRIPTION
When deduplicating witnesses for learning a spec, the processing_latency field should be ignored as it will vary unpredicably.