### PR TITLE
Add utility for computing spec hash keys

### DIFF
--- a/spec_util/hash_keys.go
+++ b/spec_util/hash_keys.go
@@ -19,8 +19,16 @@ func (vis *hashOneOfVisitor) VisitData(c http_rest.HttpRestSpecVisitorContext, p
 	if oneOf == nil {
 		return true
 	}
+
 	options := p.GetOneof().Options
-	for k, v := range options {
+	keys := make([]string, 0, len(options))
+
+	for k, _ := range options {
+		keys = append(keys, k)
+	}
+
+	for _, k := range keys {
+		v := options[k]
 		h, err := pbhash.HashProto(v)
 		if err != nil {
 			vis.err = err
@@ -52,7 +60,12 @@ func RewriteHashKeys(spec *pb.APISpec) error {
 	// Hash Args and Responses for each method.
 	for _, method := range spec.Methods {
 		for _, m := range []map[string]*pb.Data{method.Args, method.Responses} {
-			for k, arg := range m {
+			keys := make([]string, 0, len(m))
+			for k, _ := range m {
+				keys = append(keys, k)
+			}
+			for _, k := range keys {
+				arg := m[k]
 				h, err := pbhash.HashProto(arg)
 				if err != nil {
 					return errors.Wrap(err, "failed to compute hash of method argument")

--- a/spec_util/hash_keys.go
+++ b/spec_util/hash_keys.go
@@ -1,0 +1,69 @@
+package spec_util
+
+import (
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
+	"github.com/pkg/errors"
+
+	"github.com/akitasoftware/akita-libs/pbhash"
+	"github.com/akitasoftware/akita-libs/visitors/go_ast"
+	"github.com/akitasoftware/akita-libs/visitors/http_rest"
+)
+
+type hashOneOfVisitor struct {
+	http_rest.DefaultHttpRestSpecVisitor
+	err error
+}
+
+func (vis *hashOneOfVisitor) VisitData(c http_rest.HttpRestSpecVisitorContext, p *pb.Data) bool {
+	oneOf := p.GetOneof()
+	if oneOf == nil {
+		return true
+	}
+	options := p.GetOneof().Options
+	for k, v := range options {
+		h, err := pbhash.HashProto(v)
+		if err != nil {
+			vis.err = err
+			return false
+		}
+		if k != h {
+			delete(options, k)
+			options[h] = v
+		}
+	}
+	return true
+}
+
+// Three maps in the IR use hashes of the values as keys (i.e. map[hash(v)] = v):
+//  - Method.Args
+//  - Method.Responses
+//  - OneOf.Options
+//
+// This method traverses the spec, recomputes the hash of each value, and updates the map.
+func RewriteHashKeys(spec *pb.APISpec) error {
+	// Hash OneOf values in postorder, so that children are updated before computing the
+	// new hash for the parent.
+	v := &hashOneOfVisitor{}
+	http_rest.Apply(go_ast.POSTORDER, v, spec)
+	if v.err != nil {
+		return errors.Wrap(v.err, "failed to compute hash of oneOf data")
+	}
+
+	// Hash Args and Responses for each method.
+	for _, method := range spec.Methods {
+		for _, m := range []map[string]*pb.Data{method.Args, method.Responses} {
+			for k, arg := range m {
+				h, err := pbhash.HashProto(arg)
+				if err != nil {
+					return errors.Wrap(err, "failed to compute hash of method argument")
+				}
+				if h != k {
+					delete(m, k)
+					m[h] = arg
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/spec_util/hash_keys_test.go
+++ b/spec_util/hash_keys_test.go
@@ -1,0 +1,29 @@
+package spec_util
+
+import (
+	"fmt"
+	"testing"
+
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/akitasoftware/akita-libs/test"
+)
+
+func TestHashKeyRewrite(t *testing.T) {
+	// We reuse test data from meld_test, because the expected witnesses
+	// cover a range of expected IR objects.
+	for _, testData := range tests {
+		fmt.Printf("COLE: %s\n", testData.name)
+		witness := test.LoadWitnessFromFileOrDile(testData.expectedWitnessFile)
+		expected := test.LoadWitnessFromFileOrDile(testData.expectedWitnessFile)
+
+		// Witnesses are just specs with a single method.
+		err := RewriteHashKeys(&pb.APISpec{
+			Methods: []*pb.Method{witness.Method},
+		})
+		assert.NoError(t, err, testData.name)
+		assert.Equal(t, proto.MarshalTextString(expected), proto.MarshalTextString(witness), testData.name)
+	}
+}

--- a/spec_util/hash_keys_test.go
+++ b/spec_util/hash_keys_test.go
@@ -1,7 +1,6 @@
 package spec_util
 
 import (
-	"fmt"
 	"testing"
 
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
@@ -15,7 +14,6 @@ func TestHashKeyRewrite(t *testing.T) {
 	// We reuse test data from meld_test, because the expected witnesses
 	// cover a range of expected IR objects.
 	for _, testData := range tests {
-		fmt.Printf("COLE: %s\n", testData.name)
 		witness := test.LoadWitnessFromFileOrDile(testData.expectedWitnessFile)
 		expected := test.LoadWitnessFromFileOrDile(testData.expectedWitnessFile)
 

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -106,7 +106,7 @@ var tests = []testData{
 	},
 	{
 		// meld(oneof(T1, T2), T3) => oneof(T1, T2, T3)
-		"meld additive oneof",
+		"meld additive oneof with primitive",
 		[]string{
 			"testdata/meld/meld_oneof_with_primitive_1.pb.txt",
 			"testdata/meld/meld_oneof_with_primitive_2.pb.txt",

--- a/spec_util/testdata/meld/meld_additive_oneof_1.pb.txt
+++ b/spec_util/testdata/meld/meld_additive_oneof_1.pb.txt
@@ -24,7 +24,7 @@ method: {
                 }
               }
               options: {
-                key: "naAThnYPT5A="
+                key: "tyPWfpWnavU="
                 value: {
                   struct: {
                     fields: {

--- a/spec_util/testdata/meld/meld_additive_oneof_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_additive_oneof_expected.pb.txt
@@ -2,7 +2,7 @@
 
 method: {
   responses: {
-    key:"h5NvuS7asm0="
+    key:"IEVcH5ArnKs="
     value: {
       struct: {
         fields: {
@@ -38,7 +38,7 @@ method: {
                 }
               }
               options: {
-                key: "naAThnYPT5A="
+                key: "tyPWfpWnavU="
                 value: {
                   struct: {
                     fields: {

--- a/spec_util/testdata/meld/meld_oneof_with_primitive_1.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_primitive_1.pb.txt
@@ -24,7 +24,7 @@ method: {
                 }
               }
               options: {
-                key: "naAThnYPT5A="
+                key: "tyPWfpWnavU="
                 value: {
                   struct: {
                     fields: {

--- a/spec_util/testdata/meld/meld_oneof_with_primitive_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_primitive_expected.pb.txt
@@ -2,7 +2,7 @@
 
 method: {
   responses: {
-    key:"h5NvuS7asm0="
+    key:"IEVcH5ArnKs="
     value: {
       struct: {
         fields: {
@@ -38,7 +38,7 @@ method: {
                 }
               }
               options: {
-                key: "naAThnYPT5A="
+                key: "tyPWfpWnavU="
                 value: {
                   struct: {
                     fields: {

--- a/spec_util/testdata/meld/meld_with_existing_conflict_1.pb.txt
+++ b/spec_util/testdata/meld/meld_with_existing_conflict_1.pb.txt
@@ -14,7 +14,7 @@ method: {
       oneof: {
         potential_conflict: true
         options: {
-          key: "struct1"
+          key: "ZnMYW-0YN9c="
           value: {
             struct: {
               fields: {
@@ -29,7 +29,7 @@ method: {
           }
         }
         options: {
-          key: "null1"
+          key: "DbM2pDwZ79k="
           value: {
             optional: {
               none: {}

--- a/spec_util/testdata/meld/meld_with_existing_conflict_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_with_existing_conflict_expected.pb.txt
@@ -9,12 +9,12 @@ method: {
     }
   }
   responses: {
-    key: "AAKf9Joso04="
+    key: "Xc9aQTKyoNQ="
     value: {
       oneof: {
         potential_conflict: true
         options: {
-          key: "struct1"
+          key: "ZnMYW-0YN9c="
           value: {
             struct: {
               fields: {
@@ -53,7 +53,7 @@ method: {
           }
         }
         options: {
-          key: "null1"
+          key: "DbM2pDwZ79k="
           value: {
             optional: {
               none: {}


### PR DESCRIPTION
Some IR objects (Method.Args, Method.Responses, and Data.OneOf) require that
their map keys be hashes of the corresponding data values, e.g. map[hash(v)] =
v.  This PR adds a utility function for recomputing hash keys.

It also updates some unit test files that, it turns out, did not respect this
invariant.