### PR TITLE
Extended IR visitor framework

### DIFF
--- a/visitors/go_ast/ast_visitor.go
+++ b/visitors/go_ast/ast_visitor.go
@@ -8,19 +8,8 @@ import (
 	"strconv"
 	"unicode"
 
-	"github.com/akitasoftware/akita-libs/visitors"
+	. "github.com/akitasoftware/akita-libs/visitors"
 )
-
-type TraversalOrder int
-
-const (
-	PREORDER = iota
-	POSTORDER
-)
-
-func (t TraversalOrder) String() string {
-	return []string{"PREORDER", "POSTORDER"}[t]
-}
 
 // Structurally recurses through `a`.  At each term, invokes
 //
@@ -28,69 +17,135 @@ func (t TraversalOrder) String() string {
 //
 // Aborts the traversal if v.Apply returns false.
 //
-func Apply(order TraversalOrder, v visitors.VisitorManager, a interface{}) bool {
-	astv := astVisitor{order: order, vm: v}
+func Apply(v VisitorManager, a interface{}) Cont {
+	astv := astVisitor{vm: v}
 	return astv.visit(v.Context(), a)
 }
 
 type astVisitor struct {
-	order TraversalOrder
-	vm    visitors.VisitorManager
+	vm VisitorManager
 }
 
-func (t *astVisitor) visit(c visitors.Context, m interface{}) bool {
+// Visits the node m, whose context is c. This should never return SkipChildren.
+func (t *astVisitor) visit(c Context, m interface{}) Cont {
 	if m == nil {
-		return true
+		return Continue
 	}
-	keepGoing := true
 
-	if t.order == PREORDER {
-		keepGoing = t.vm.Apply(c, t.vm.Visitor(), m)
-		if !keepGoing {
-			return false
-		}
+	keepGoing := t.vm.EnterNode(c, t.vm.Visitor(), m)
+	switch keepGoing {
+	case Abort:
+		return Abort
+	case Continue:
+	case SkipChildren:
+	case Stop:
+	default:
+		panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
 	}
 
 	newContext := t.vm.ExtendContext(c, t.vm.Visitor(), m)
 
-	// Traverse m's children
-	mt := reflect.TypeOf(m)
-	mv := reflect.ValueOf(m)
+	// Don't visit children if we are stopping or skipping children.
+	if keepGoing == Continue {
+		// Traverse m's children.
+		mt := reflect.TypeOf(m)
+		mv := reflect.ValueOf(m)
 
-	// If we visited a pointer, don't also visit the object; just descend into it
-	for mt.Kind() == reflect.Ptr {
-		if mv.IsNil() {
-			return true
-		}
-		mt = mt.Elem()
-		mv = mv.Elem()
-	}
-
-	// Recurse into data structures.  Extend the context when visiting
-	// children, but not between siblings.
-	if mt.Kind() == reflect.Struct {
-		for i := 0; i < mt.NumField(); i++ {
-			ft := mt.Field(i)
-			fv := mv.Field(i)
-			// Skip private fields and invalid values.
-			if !fv.IsValid() || unicode.IsLower([]rune(ft.Name)[0]) {
-				continue
+		// If we visited a pointer, don't also visit the object; just descend into
+		// it.
+		for mt.Kind() == reflect.Ptr {
+			if mv.IsNil() {
+				return Continue
 			}
-			keepGoing = t.visit(newContext.AppendPath(ft.Name), mv.Field(i).Interface())
+			mt = mt.Elem()
+			mv = mv.Elem()
 		}
-	} else if mt.Kind() == reflect.Array || mt.Kind() == reflect.Slice {
-		for i := 0; i < mv.Len(); i++ {
-			keepGoing = t.visit(newContext.AppendPath(strconv.Itoa(i)), mv.Index(i).Interface())
-		}
-	} else if mt.Kind() == reflect.Map {
-		// TODO(cs): Need to visit (k,v), then k, then v for each k, v.
-		for _, k := range mv.MapKeys() {
-			keepGoing = t.visit(newContext.AppendPath(fmt.Sprint(k.Interface())), mv.MapIndex(k).Interface())
+
+		// Recurse into data structures.  Extend the context when visiting
+		// children, but not between siblings.
+		if mt.Kind() == reflect.Struct {
+			keepGoing = t.visitStructChildren(newContext, mt, mv, keepGoing)
+		} else if mt.Kind() == reflect.Array || mt.Kind() == reflect.Slice {
+			keepGoing = t.visitArrayChildren(newContext, mv, keepGoing)
+		} else if mt.Kind() == reflect.Map {
+			keepGoing = t.visitMapChildren(newContext, mv, keepGoing)
 		}
 	}
 
-	if t.order == POSTORDER && keepGoing {
-		keepGoing = t.vm.Apply(c, t.vm.Visitor(), m)
+	keepGoing = t.vm.LeaveNode(c, t.vm.Visitor(), m, keepGoing)
+
+	// For convenience, convert SkipChildren into Continue, so that LeaveNode
+	// implementations can just return keepGoing unchanged.
+	if keepGoing == SkipChildren {
+		keepGoing = Continue
+	}
+	return keepGoing
+}
+
+// Helper for visiting the children of a struct mv having type mt in context
+// ctx.
+func (t *astVisitor) visitStructChildren(ctx Context, mt reflect.Type, mv reflect.Value, keepGoing Cont) Cont {
+	for i := 0; i < mt.NumField(); i++ {
+		ft := mt.Field(i)
+		fv := mv.Field(i)
+
+		// Skip private fields and invalid values.
+		if !fv.IsValid() || unicode.IsLower([]rune(ft.Name)[0]) {
+			continue
+		}
+
+		keepGoing = t.visit(ctx.AppendPath(ft.Name), mv.Field(i).Interface())
+
+		switch keepGoing {
+		case Abort, Stop:
+			return keepGoing
+		case Continue:
+		case SkipChildren:
+			panic(fmt.Sprintf("astVisitor.visit returned SkipChildren"))
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+
+	return keepGoing
+}
+
+// Helper for visiting the children of an array mv in context ctx.
+func (t *astVisitor) visitArrayChildren(ctx Context, mv reflect.Value, keepGoing Cont) Cont {
+	for i := 0; i < mv.Len(); i++ {
+		keepGoing = t.visit(ctx.AppendPath(strconv.Itoa(i)), mv.Index(i).Interface())
+		switch keepGoing {
+		case Abort:
+			return Abort
+		case Continue:
+		case SkipChildren:
+			panic(fmt.Sprintf("astVisitor.visit returned SkipChildren"))
+		case Stop:
+			break
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+
+	return keepGoing
+}
+
+// Helper for visiting the children of a map mv in context ctx.
+func (t *astVisitor) visitMapChildren(ctx Context, mv reflect.Value, keepGoing Cont) Cont {
+	// TODO(cs): Need to visit (k,v), then k, then v for each k, v.
+	for _, k := range mv.MapKeys() {
+		keepGoing = t.visit(ctx.AppendPath(fmt.Sprint(k.Interface())), mv.MapIndex(k).Interface())
+		switch keepGoing {
+		case Abort:
+			return Abort
+		case Continue:
+		case SkipChildren:
+			panic(fmt.Sprintf("astVisitor.visit returned SkipChildren"))
+		case Stop:
+			break
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
 	}
 
 	return keepGoing

--- a/visitors/go_ast/ast_visitor.go
+++ b/visitors/go_ast/ast_visitor.go
@@ -11,15 +11,14 @@ import (
 	. "github.com/akitasoftware/akita-libs/visitors"
 )
 
-// Structurally recurses through `a`.  At each term, invokes
-//
-//   c, keepGoing := v.Apply(c, v.Visitor(), t)
-//
-// Aborts the traversal if v.Apply returns false.
-//
-func Apply(v VisitorManager, a interface{}) Cont {
+// Structurally recurses through `node`.
+func Apply(v VisitorManager, node interface{}) Cont {
+	return ApplyWithContext(v, v.Context(), node)
+}
+
+func ApplyWithContext(v VisitorManager, ctx Context, node interface{}) Cont {
 	astv := astVisitor{vm: v}
-	return astv.visit(v.Context(), a)
+	return astv.visit(ctx, node)
 }
 
 type astVisitor struct {

--- a/visitors/go_ast/ast_visitor.go
+++ b/visitors/go_ast/ast_visitor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"unicode"
 
 	. "github.com/akitasoftware/akita-libs/visitors"
@@ -100,6 +101,12 @@ func (t *astVisitor) visitStructChildren(ctx Context, mt reflect.Type, mv reflec
 
 		// Skip private fields and invalid values.
 		if !fv.IsValid() || unicode.IsLower([]rune(ft.Name)[0]) {
+			continue
+		}
+
+		// XXX Skip Protobuf-generated fields, identified by names beginning with
+		// "XXX_"
+		if strings.HasPrefix(ft.Name, "XXX_") {
 			continue
 		}
 

--- a/visitors/go_ast/ast_visitor_test.go
+++ b/visitors/go_ast/ast_visitor_test.go
@@ -35,7 +35,7 @@ func extendContext(c Context, v interface{}, x interface{}) Context {
 
 func TestApply(t *testing.T) {
 	counter := new(Counter)
-	vm := NewVisitorManager(NewContext(), counter, countIntEnter, countIntLeave, extendContext)
+	vm := NewVisitorManager(NewContext(), counter, countIntEnter, DefaultVisitChildren, countIntLeave, extendContext)
 	d := []int{1, 2, 3}
 	Apply(vm, d)
 	assert.Equal(t, 3, counter.enterCount)

--- a/visitors/go_ast/ast_visitor_test.go
+++ b/visitors/go_ast/ast_visitor_test.go
@@ -29,7 +29,7 @@ func countIntLeave(c Context, v interface{}, x interface{}, cont Cont) Cont {
 	return cont
 }
 
-func extendContext(c Context, v interface{}, x interface{}) Context {
+func extendContext(c Context, x interface{}) Context {
 	return c
 }
 

--- a/visitors/go_ast/ast_visitor_test.go
+++ b/visitors/go_ast/ast_visitor_test.go
@@ -5,29 +5,39 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/akitasoftware/akita-libs/visitors"
+	. "github.com/akitasoftware/akita-libs/visitors"
 )
 
 type Counter struct {
-	count int
+	enterCount int
+	leaveCount int
 }
 
-func countInt(c visitors.Context, v interface{}, x interface{}) bool {
+func countIntEnter(c Context, v interface{}, x interface{}) Cont {
 	counter := v.(*Counter)
 	if _, ok := x.(int); ok {
-		counter.count++
+		counter.enterCount++
 	}
-	return true
+	return Continue
 }
 
-func extendContext(c visitors.Context, v interface{}, x interface{}) visitors.Context {
+func countIntLeave(c Context, v interface{}, x interface{}, cont Cont) Cont {
+	counter := v.(*Counter)
+	if _, ok := x.(int); ok {
+		counter.leaveCount++
+	}
+	return cont
+}
+
+func extendContext(c Context, v interface{}, x interface{}) Context {
 	return c
 }
 
 func TestApply(t *testing.T) {
 	counter := new(Counter)
-	vm := visitors.NewVisitorManager(visitors.NewContext(), counter, countInt, extendContext)
+	vm := NewVisitorManager(NewContext(), counter, countIntEnter, countIntLeave, extendContext)
 	d := []int{1, 2, 3}
-	Apply(PREORDER, vm, d)
-	assert.Equal(t, 3, counter.count)
+	Apply(vm, d)
+	assert.Equal(t, 3, counter.enterCount)
+	assert.Equal(t, 3, counter.leaveCount)
 }

--- a/visitors/go_ast_pair/ast_pair_visitor.go
+++ b/visitors/go_ast_pair/ast_pair_visitor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"unicode"
 
 	. "github.com/akitasoftware/akita-libs/visitors"
@@ -130,6 +131,12 @@ func (t *astPairVisitor) visitStructChildren(ctx PairContext, leftT reflect.Type
 			continue
 		}
 
+		// XXX Skip Protobuf-generated fields, identified by names beginning with
+		// "XXX_"
+		if strings.HasPrefix(fieldName, "XXX_") {
+			continue
+		}
+
 		namesVisited[fieldName] = struct{}{}
 
 		rightFieldV := rightV.FieldByName(fieldName)
@@ -161,6 +168,12 @@ func (t *astPairVisitor) visitStructChildren(ctx PairContext, leftT reflect.Type
 		// Skip private fields and invalid values.
 		rightFieldV := rightV.Field(i)
 		if !rightFieldV.IsValid() || unicode.IsLower([]rune(fieldName)[0]) {
+			continue
+		}
+
+		// XXX Skip Protobuf-generated fields, identified by names beginning with
+		// "XXX_"
+		if strings.HasPrefix(fieldName, "XXX_") {
 			continue
 		}
 

--- a/visitors/go_ast_pair/ast_pair_visitor.go
+++ b/visitors/go_ast_pair/ast_pair_visitor.go
@@ -25,7 +25,11 @@ type astPairVisitor struct {
 }
 
 // Visits the nodes left and right in tandem, whose context is c. At least one
-// of left or right must be non-nil. This should never return SkipChildren.
+// of left or right must be non-nil. When the visitor finds a structural
+// difference between the two sides (e.g., one side is nil or the two sides
+// have different kinds), the nodes are entered, but their children are not.
+//
+// This should never return SkipChildren.
 func (t *astPairVisitor) visit(c PairContext, left, right interface{}) Cont {
 	if left == nil && right == nil {
 		return Continue

--- a/visitors/go_ast_pair/ast_pair_visitor.go
+++ b/visitors/go_ast_pair/ast_pair_visitor.go
@@ -1,0 +1,281 @@
+package go_ast_pair
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"unicode"
+
+	. "github.com/akitasoftware/akita-libs/visitors"
+)
+
+// Structurally recurses through `leftNode` and `rightNode` in tandem.
+func Apply(v PairVisitorManager, leftNode, rightNode interface{}) Cont {
+	return ApplyWithContext(v, v.Context(), leftNode, rightNode)
+}
+
+func ApplyWithContext(v PairVisitorManager, ctx PairContext, leftNode, rightNode interface{}) Cont {
+	astv := astPairVisitor{vm: v}
+	return astv.visit(ctx, leftNode, rightNode)
+}
+
+type astPairVisitor struct {
+	vm PairVisitorManager
+}
+
+// Visits the nodes left and right in tandem, whose context is c. At least one
+// of left or right must be non-nil. This should never return SkipChildren.
+func (t *astPairVisitor) visit(c PairContext, left, right interface{}) Cont {
+	if left == nil && right == nil {
+		return Continue
+	}
+
+	keepGoing := t.vm.EnterNodes(c, t.vm.Visitor(), left, right)
+	switch keepGoing {
+	case Abort:
+		return Abort
+	case Continue:
+	case SkipChildren:
+	case Stop:
+	default:
+		panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+	}
+
+	// Don't visit children if we are stopping or skipping children.
+	if keepGoing == Continue {
+		newContext := t.vm.ExtendContext(c, left, right)
+		keepGoing = t.vm.VisitChildren(newContext, t.vm, left, right)
+	}
+
+	keepGoing = t.vm.LeaveNodes(c, t.vm.Visitor(), left, right, keepGoing)
+
+	// For convenience, convert SkipChildren into Continue, so that LeaveNodes
+	// implementations can just return keepGoing unchanged.
+	if keepGoing == SkipChildren {
+		keepGoing = Continue
+	}
+	return keepGoing
+}
+
+func DefaultVisitChildren(newContext PairContext, vm PairVisitorManager, left, right interface{}) Cont {
+	if left == nil {
+		return Continue
+	}
+	leftT := reflect.TypeOf(left)
+	leftV := reflect.ValueOf(left)
+
+	if right == nil {
+		return Continue
+	}
+	rightT := reflect.TypeOf(right)
+	rightV := reflect.ValueOf(right)
+
+	// If we visited a pointer, don't also visit the object; just descend into
+	// it. Prune the traversal if left or right is nil.
+	for leftT.Kind() == reflect.Ptr {
+		if leftV.IsNil() {
+			return Continue
+		}
+		leftT = leftT.Elem()
+		leftV = leftV.Elem()
+	}
+	for rightT.Kind() == reflect.Ptr {
+		if rightV.IsNil() {
+			return Continue
+		}
+		rightT = rightT.Elem()
+		rightV = rightV.Elem()
+	}
+
+	// Don't visit children if left and right have different kinds.
+	if leftT.Kind() != rightT.Kind() {
+		return Continue
+	}
+
+	// Recurse into data structures. Extend the context when visiting children,
+	// but not between siblings.
+	astv := astPairVisitor{vm: vm}
+	switch leftT.Kind() {
+	case reflect.Struct:
+		return astv.visitStructChildren(newContext, leftT, leftV, rightT, rightV)
+
+	case reflect.Array, reflect.Slice:
+		return astv.visitArrayChildren(newContext, leftV, rightV)
+
+	case reflect.Map:
+		// Don't visit children if left and right have different key types.
+		if leftT.Key() != rightT.Key() {
+			return Continue
+		}
+		return astv.visitMapChildren(newContext, leftV, rightV)
+
+	default:
+		return Continue
+	}
+}
+
+// Helper for visiting the children of structs leftV and rightV having
+// respective types leftT and rightT in context ctx.
+func (t *astPairVisitor) visitStructChildren(ctx PairContext, leftT reflect.Type, leftV reflect.Value, rightT reflect.Type, rightV reflect.Value) Cont {
+	keepGoing := Continue
+	namesVisited := make(map[string]struct{})
+
+	// Visit fields on the left.
+	for i := 0; i < leftT.NumField(); i++ {
+		fieldName := leftT.Field(i).Name
+		leftFieldV := leftV.Field(i)
+
+		// Skip private fields and invalid values.
+		if !leftFieldV.IsValid() || unicode.IsLower([]rune(fieldName)[0]) {
+			continue
+		}
+
+		namesVisited[fieldName] = struct{}{}
+
+		rightFieldV := rightV.FieldByName(fieldName)
+		if rightFieldV.IsValid() {
+			keepGoing = t.visit(ctx.AppendPaths(fieldName, fieldName), leftFieldV.Interface(), rightFieldV.Interface())
+		} else {
+			keepGoing = t.visit(ctx.AppendPaths(fieldName, fieldName), leftFieldV.Interface(), nil)
+		}
+
+		switch keepGoing {
+		case Abort, Stop:
+			return keepGoing
+		case Continue:
+		case SkipChildren:
+			panic("astPairVisitor.visit returned SkipChildren")
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+
+	// Visit any unvisited fields on the right.
+	for i := 0; i < rightT.NumField(); i++ {
+		fieldName := rightT.Field(i).Name
+		if _, ok := namesVisited[fieldName]; ok {
+			// Field already visited.
+			continue
+		}
+
+		// Skip private fields and invalid values.
+		rightFieldV := rightV.Field(i)
+		if !rightFieldV.IsValid() || unicode.IsLower([]rune(fieldName)[0]) {
+			continue
+		}
+
+		keepGoing = t.visit(ctx.AppendPaths(fieldName, fieldName), nil, rightFieldV.Interface())
+
+		switch keepGoing {
+		case Abort, Stop:
+			return keepGoing
+		case Continue:
+		case SkipChildren:
+			panic("astPairVisitor.visit returned SkipChildren")
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+
+	return keepGoing
+}
+
+// Helper for visiting the children of arrays leftV and rightV having
+// respective types leftT and rightT in context ctx.
+func (t *astPairVisitor) visitArrayChildren(ctx PairContext, leftV, rightV reflect.Value) Cont {
+	keepGoing := Continue
+	for i := 0; i < leftV.Len() || i < rightV.Len(); i++ {
+		var leftElt interface{} = nil
+		var rightElt interface{} = nil
+
+		if i < leftV.Len() {
+			leftElt = leftV.Index(i).Interface()
+		}
+
+		if i < rightV.Len() {
+			rightElt = rightV.Index(i).Interface()
+		}
+
+		idxStr := strconv.Itoa(i)
+		keepGoing = t.visit(ctx.AppendPaths(idxStr, idxStr), leftElt, rightElt)
+		switch keepGoing {
+		case Abort:
+			return Abort
+		case Continue:
+		case SkipChildren:
+			panic("astPairVisitor.visit returned SkipChildren")
+		case Stop:
+			return Stop
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+
+	return keepGoing
+}
+
+// Helper for visiting the children of maps leftV and rightV in context ctx.
+// Assumes that the two maps have the same key type.
+func (t *astPairVisitor) visitMapChildren(ctx PairContext, leftV, rightV reflect.Value) Cont {
+	// TODO(cs): Need to visit (k,v), then k, then v for each k, v.
+	keepGoing := Continue
+
+	// Build a set of keys for each map.
+	leftKeys := make(map[interface{}]struct{})
+	for _, k := range leftV.MapKeys() {
+		leftKeys[k.Interface()] = struct{}{}
+	}
+	rightKeys := make(map[interface{}]struct{})
+	for _, k := range rightV.MapKeys() {
+		rightKeys[k.Interface()] = struct{}{}
+	}
+
+	// Visit values on left.
+	for _, k := range leftV.MapKeys() {
+		leftElt := leftV.MapIndex(k).Interface()
+
+		var rightElt interface{} = nil
+		if _, ok := rightKeys[k.Interface()]; ok {
+			rightElt = rightV.MapIndex(k).Interface()
+		}
+
+		pathStr := fmt.Sprint(k.Interface())
+		keepGoing = t.visit(ctx.AppendPaths(pathStr, pathStr), leftElt, rightElt)
+		switch keepGoing {
+		case Abort:
+			return Abort
+		case Continue:
+		case SkipChildren:
+			panic("astPairVisitor.visit returned SkipChildren")
+		case Stop:
+			return Stop
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+
+	// Visit any unvisited values on right.
+	for _, k := range rightV.MapKeys() {
+		if _, ok := leftKeys[k.Interface()]; ok {
+			// Already visited.
+			continue
+		}
+
+		rightElt := rightV.MapIndex(k).Interface()
+		pathStr := fmt.Sprint(k.Interface())
+		keepGoing = t.visit(ctx.AppendPaths(pathStr, pathStr), nil, rightElt)
+		switch keepGoing {
+		case Abort:
+			return Abort
+		case Continue:
+		case SkipChildren:
+			panic("astPairVisitor.visit returned SkipChildren")
+		case Stop:
+			return Stop
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+
+	return keepGoing
+}

--- a/visitors/go_ast_pair/ast_pair_visitor_test.go
+++ b/visitors/go_ast_pair/ast_pair_visitor_test.go
@@ -1,0 +1,55 @@
+package go_ast_pair
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/akitasoftware/akita-libs/visitors"
+)
+
+type Counter struct {
+	enterCount int
+	leaveCount int
+}
+
+func countIntEnter(c PairContext, v interface{}, left, right interface{}) Cont {
+	counter := v.(*Counter)
+	_, leftOk := left.(int)
+	_, rightOk := right.(int)
+	if leftOk || rightOk {
+		counter.enterCount++
+	}
+	return Continue
+}
+
+func countIntLeave(c PairContext, v interface{}, left, right interface{}, cont Cont) Cont {
+	counter := v.(*Counter)
+	_, leftOk := left.(int)
+	_, rightOk := right.(int)
+	if leftOk || rightOk {
+		counter.leaveCount++
+	}
+	return cont
+}
+
+func extendContext(c PairContext, left, right interface{}) PairContext {
+	return c
+}
+
+func TestApply(t *testing.T) {
+	counter := new(Counter)
+	vm := NewPairVisitorManager(NewPairContext(), counter, countIntEnter, DefaultVisitChildren, countIntLeave, extendContext)
+
+	left := make(map[interface{}]int)
+	left["moo"] = 0
+	left[struct{ a int }{a: 1}] = 0
+
+	right := make(map[interface{}]int)
+	right[struct{ a int }{a: 1}] = 0
+	right[2] = 0
+
+	Apply(vm, left, right)
+	assert.Equal(t, 3, counter.enterCount)
+	assert.Equal(t, 3, counter.leaveCount)
+}

--- a/visitors/http_rest/http_rest_spec_pair_visitor.go
+++ b/visitors/http_rest/http_rest_spec_pair_visitor.go
@@ -10,8 +10,11 @@ import (
 	"github.com/akitasoftware/akita-libs/visitors/go_ast_pair"
 )
 
-// PairVisitorManager that lets you read each message in a pair of APISpecs,
-// starting with the APISpec messages themselves.
+// A PairVisitorManager that lets you read each message in a pair of APISpecs,
+// starting with the APISpec messages themselves. When the visitor encounters
+// a type difference between the two halves of the pair, EnterDifferentTypes
+// and LeaveDifferentTypes is used to enter and leave the nodes, but the nodes'
+// children are not visited; EnterDifferentTypes must never return Continue.
 type HttpRestSpecPairVisitor interface {
 	EnterAPISpecs(HttpRestSpecPairVisitorContext, *pb.APISpec, *pb.APISpec) Cont
 	VisitAPISpecChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.APISpec, *pb.APISpec) Cont

--- a/visitors/http_rest/http_rest_spec_pair_visitor.go
+++ b/visitors/http_rest/http_rest_spec_pair_visitor.go
@@ -719,7 +719,7 @@ func leavePair(cin PairContext, visitor interface{}, left, right interface{}, co
 
 // Visits left and right with v in tandem.
 func ApplyPair(v HttpRestSpecPairVisitor, left, right interface{}) Cont {
-	c := new(httpRestSpecPairVisitorContext)
+	c := newHttpRestSpecPairVisitorContext()
 	vis := NewPairVisitorManager(c, v, enterPair, visitPairChildren, leavePair, extendPairContext)
 	return go_ast_pair.Apply(vis, left, right)
 }

--- a/visitors/http_rest/http_rest_spec_pair_visitor.go
+++ b/visitors/http_rest/http_rest_spec_pair_visitor.go
@@ -1,0 +1,620 @@
+package http_rest
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
+	. "github.com/akitasoftware/akita-libs/visitors"
+	"github.com/akitasoftware/akita-libs/visitors/go_ast_pair"
+)
+
+// PairVisitorManager that lets you read each message in a pair of APISpecs,
+// starting with the APISpec messages themselves.
+type HttpRestSpecPairVisitor interface {
+	EnterAPISpecs(HttpRestSpecPairVisitorContext, *pb.APISpec, *pb.APISpec) Cont
+	VisitAPISpecChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.APISpec, *pb.APISpec) Cont
+	LeaveAPISpecs(HttpRestSpecPairVisitorContext, *pb.APISpec, *pb.APISpec, Cont) Cont
+
+	EnterMethods(HttpRestSpecPairVisitorContext, *pb.Method, *pb.Method) Cont
+	VisitMethodChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.Method, *pb.Method) Cont
+	LeaveMethods(HttpRestSpecPairVisitorContext, *pb.Method, *pb.Method, Cont) Cont
+
+	EnterMethodMetas(HttpRestSpecPairVisitorContext, *pb.MethodMeta, *pb.MethodMeta) Cont
+	VisitMethodMetaChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.MethodMeta, *pb.MethodMeta) Cont
+	LeaveMethodMetas(HttpRestSpecPairVisitorContext, *pb.MethodMeta, *pb.MethodMeta, Cont) Cont
+
+	EnterHTTPMethodMetas(HttpRestSpecPairVisitorContext, *pb.HTTPMethodMeta, *pb.HTTPMethodMeta) Cont
+	VisitHTTPMethodMetaChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPMethodMeta, *pb.HTTPMethodMeta) Cont
+	LeaveHTTPMethodMetas(HttpRestSpecPairVisitorContext, *pb.HTTPMethodMeta, *pb.HTTPMethodMeta, Cont) Cont
+
+	EnterData(HttpRestSpecPairVisitorContext, *pb.Data, *pb.Data) Cont
+	VisitDataChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.Data, *pb.Data) Cont
+	LeaveData(HttpRestSpecPairVisitorContext, *pb.Data, *pb.Data, Cont) Cont
+
+	EnterDataMetas(HttpRestSpecPairVisitorContext, *pb.DataMeta, *pb.DataMeta) Cont
+	VisitDataMetaChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.DataMeta, *pb.DataMeta) Cont
+	LeaveDataMetas(HttpRestSpecPairVisitorContext, *pb.DataMeta, *pb.DataMeta, Cont) Cont
+
+	EnterHTTPMetas(HttpRestSpecPairVisitorContext, *pb.HTTPMeta, *pb.HTTPMeta) Cont
+	VisitHTTPMetaChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPMeta, *pb.HTTPMeta) Cont
+	LeaveHTTPMetas(HttpRestSpecPairVisitorContext, *pb.HTTPMeta, *pb.HTTPMeta, Cont) Cont
+
+	EnterHTTPPaths(HttpRestSpecPairVisitorContext, *pb.HTTPPath, *pb.HTTPPath) Cont
+	VisitHTTPPathChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPPath, *pb.HTTPPath) Cont
+	LeaveHTTPPaths(HttpRestSpecPairVisitorContext, *pb.HTTPPath, *pb.HTTPPath, Cont) Cont
+
+	EnterHTTPQueries(HttpRestSpecPairVisitorContext, *pb.HTTPQuery, *pb.HTTPQuery) Cont
+	VisitHTTPQueryChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPQuery, *pb.HTTPQuery) Cont
+	LeaveHTTPQueries(HttpRestSpecPairVisitorContext, *pb.HTTPQuery, *pb.HTTPQuery, Cont) Cont
+
+	EnterHTTPHeaders(HttpRestSpecPairVisitorContext, *pb.HTTPHeader, *pb.HTTPHeader) Cont
+	VisitHTTPHeaderChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPHeader, *pb.HTTPHeader) Cont
+	LeaveHTTPHeaders(HttpRestSpecPairVisitorContext, *pb.HTTPHeader, *pb.HTTPHeader, Cont) Cont
+
+	EnterHTTPCookies(HttpRestSpecPairVisitorContext, *pb.HTTPCookie, *pb.HTTPCookie) Cont
+	VisitHTTPCookieChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPCookie, *pb.HTTPCookie) Cont
+	LeaveHTTPCookies(HttpRestSpecPairVisitorContext, *pb.HTTPCookie, *pb.HTTPCookie, Cont) Cont
+
+	EnterHTTPBodies(HttpRestSpecPairVisitorContext, *pb.HTTPBody, *pb.HTTPBody) Cont
+	VisitHTTPBodyChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPBody, *pb.HTTPBody) Cont
+	LeaveHTTPBodies(HttpRestSpecPairVisitorContext, *pb.HTTPBody, *pb.HTTPBody, Cont) Cont
+
+	EnterHTTPEmpties(HttpRestSpecPairVisitorContext, *pb.HTTPEmpty, *pb.HTTPEmpty) Cont
+	VisitHTTPEmptyChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPEmpty, *pb.HTTPEmpty) Cont
+	LeaveHTTPEmpties(HttpRestSpecPairVisitorContext, *pb.HTTPEmpty, *pb.HTTPEmpty, Cont) Cont
+
+	EnterHTTPAuths(HttpRestSpecPairVisitorContext, *pb.HTTPAuth, *pb.HTTPAuth) Cont
+	VisitHTTPAuthChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPAuth, *pb.HTTPAuth) Cont
+	LeaveHTTPAuths(HttpRestSpecPairVisitorContext, *pb.HTTPAuth, *pb.HTTPAuth, Cont) Cont
+
+	EnterHTTPMultiparts(HttpRestSpecPairVisitorContext, *pb.HTTPMultipart, *pb.HTTPMultipart) Cont
+	VisitHTTPMultipartChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.HTTPMultipart, *pb.HTTPMultipart) Cont
+	LeaveHTTPMultiparts(HttpRestSpecPairVisitorContext, *pb.HTTPMultipart, *pb.HTTPMultipart, Cont) Cont
+
+	EnterPrimitives(HttpRestSpecPairVisitorContext, *pb.Primitive, *pb.Primitive) Cont
+	VisitPrimitiveChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, *pb.Primitive, *pb.Primitive) Cont
+	LeavePrimitives(HttpRestSpecPairVisitorContext, *pb.Primitive, *pb.Primitive, Cont) Cont
+
+	DefaultVisitChildren(HttpRestSpecPairVisitorContext, PairVisitorManager, interface{}, interface{}) Cont
+
+	// Used when the visitor tries to enter two nodes with different types. This
+	// cannot return Continue; otherwise, visitChildren will panic.
+	EnterDifferentTypes(HttpRestSpecPairVisitorContext, interface{}, interface{}) Cont
+
+	// Used when the visitor tries to leave two nodes with different types.
+	LeaveDifferentTypes(HttpRestSpecPairVisitorContext, interface{}, interface{}, Cont) Cont
+}
+
+type DefaultHttpRestSpecPairVisitor struct{}
+
+func (*DefaultHttpRestSpecPairVisitor) DefaultVisitChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right interface{}) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+// == APISpec =================================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterAPISpecs(c HttpRestSpecPairVisitorContext, left, right *pb.APISpec) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitAPISpecChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.APISpec) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveAPISpecs(c HttpRestSpecPairVisitorContext, left, right *pb.APISpec, cont Cont) Cont {
+	return cont
+}
+
+// == Method ==================================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterMethods(c HttpRestSpecPairVisitorContext, left, right *pb.Method) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitMethodChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.Method) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveMethods(c HttpRestSpecPairVisitorContext, left, right *pb.Method, cont Cont) Cont {
+	return cont
+}
+
+// == MethodMeta ==============================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterMethodMetas(c HttpRestSpecPairVisitorContext, left, right *pb.MethodMeta) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitMethodMetaChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.MethodMeta) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveMethodMetas(c HttpRestSpecPairVisitorContext, left, right *pb.MethodMeta, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPMethodMeta ==========================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPMethodMetas(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPMethodMeta) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPMethodMetaChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPMethodMeta) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPMethodMetas(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPMethodMeta, cont Cont) Cont {
+	return cont
+}
+
+// == Data =====================================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterData(c HttpRestSpecPairVisitorContext, left, right *pb.Data) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitDataChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.Data) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveData(c HttpRestSpecPairVisitorContext, left, right *pb.Data, cont Cont) Cont {
+	return cont
+}
+
+// == DataMeta ================================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterDataMetas(c HttpRestSpecPairVisitorContext, left, right *pb.DataMeta) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitDataMetaChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.DataMeta) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveDataMetas(c HttpRestSpecPairVisitorContext, left, right *pb.DataMeta, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPMeta ================================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPMetas(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPMeta) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPMetaChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPMeta) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPMetas(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPMeta, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPPath ================================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPPaths(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPPath) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPPathChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPPath) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPPaths(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPPath, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPQuery ===============================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPQueries(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPQuery) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPQueryChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPQuery) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPQueries(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPQuery, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPHeader ==============================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPHeaders(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPHeader) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPHeaderChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPHeader) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPHeaders(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPHeader, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPCookie ==============================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPCookies(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPCookie) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPCookieChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPCookie) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPCookies(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPCookie, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPBody ================================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPBodies(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPBody) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPBodyChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPBody) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPBodies(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPBody, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPEmpty ===============================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPEmpties(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPEmpty) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPEmptyChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPEmpty) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPEmpties(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPEmpty, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPAuth ================================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPAuths(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPAuth) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPAuthChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPAuth) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPAuths(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPAuth, cont Cont) Cont {
+	return cont
+}
+
+// == HTTPMultipart ===========================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterHTTPMultiparts(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPMultipart) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitHTTPMultipartChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.HTTPMultipart) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveHTTPMultiparts(c HttpRestSpecPairVisitorContext, left, right *pb.HTTPMultipart, cont Cont) Cont {
+	return cont
+}
+
+// == Primitive ===============================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterPrimitives(c HttpRestSpecPairVisitorContext, left, right *pb.Primitive) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecPairVisitor) VisitPrimitiveChildren(c HttpRestSpecPairVisitorContext, vm PairVisitorManager, left, right *pb.Primitive) Cont {
+	return go_ast_pair.DefaultVisitChildren(c, vm, left, right)
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeavePrimitives(c HttpRestSpecPairVisitorContext, left, right *pb.Primitive, cont Cont) Cont {
+	return cont
+}
+
+// == Different types =========================================================
+
+func (*DefaultHttpRestSpecPairVisitor) EnterDifferentTypes(c HttpRestSpecPairVisitorContext, left, right interface{}) Cont {
+	return SkipChildren
+}
+
+func (*DefaultHttpRestSpecPairVisitor) LeaveDifferentTypes(c HttpRestSpecPairVisitorContext, left, right interface{}, cont Cont) Cont {
+	return cont
+}
+
+// extendContext implementation for HttpRestSpecPairVisitor.
+func extendPairContext(cin PairContext, left, right interface{}) PairContext {
+	ctx, ok := cin.(HttpRestSpecPairVisitorContext)
+	if !ok {
+		panic(fmt.Sprintf("http_rest.extendPairContext expected HttpRestSpecPairVisitorContext, got %s",
+			reflect.TypeOf(cin)))
+	}
+
+	ctx.ExtendLeftContext(left)
+	ctx.ExtendRightContext(right)
+	return ctx
+}
+
+// enter implementation for HttpRestSpecVisitor.
+func enterPair(cin PairContext, visitor interface{}, left, right interface{}) Cont {
+	v, _ := visitor.(HttpRestSpecPairVisitor)
+	ctx, ok := extendPairContext(cin, left, right).(HttpRestSpecPairVisitorContext)
+	if !ok {
+		panic(fmt.Sprintf("http_rest.enterPair expected HttpRestSpecPairVisitorContext, got %s",
+			reflect.TypeOf(cin)))
+	}
+	keepGoing := Continue
+
+	if reflect.TypeOf(left) != reflect.TypeOf(right) {
+		return v.EnterDifferentTypes(ctx, left, right)
+	}
+
+	// Dispatch on type and path.
+	switch leftNode := left.(type) {
+	case pb.APISpec, pb.Method, pb.MethodMeta, pb.HTTPMethodMeta, pb.Data, pb.DataMeta, pb.HTTPMeta, pb.HTTPPath, pb.HTTPQuery, pb.HTTPHeader, pb.HTTPCookie, pb.HTTPBody, pb.HTTPAuth, pb.HTTPMultipart, pb.Primitive:
+		// For simplicity, ensure we're operating on a pointer to any complex
+		// structure.
+		return enterPair(ctx, v, &leftNode, &right)
+
+	case *pb.APISpec:
+		rightNode := right.(*pb.APISpec)
+		return v.EnterAPISpecs(ctx, leftNode, rightNode)
+
+	case *pb.Method:
+		rightNode := right.(*pb.Method)
+		return v.EnterMethods(ctx, leftNode, rightNode)
+
+	case *pb.MethodMeta:
+		rightNode := right.(*pb.MethodMeta)
+		return v.EnterMethodMetas(ctx, leftNode, rightNode)
+
+	case *pb.HTTPMethodMeta:
+		rightNode := right.(*pb.HTTPMethodMeta)
+		return v.EnterHTTPMethodMetas(ctx, leftNode, rightNode)
+
+	case *pb.Data:
+		rightNode := right.(*pb.Data)
+		return v.EnterData(ctx, leftNode, rightNode)
+
+	case *pb.DataMeta:
+		rightNode := right.(*pb.DataMeta)
+		return v.EnterDataMetas(ctx, leftNode, rightNode)
+
+	case *pb.HTTPPath:
+		rightNode := right.(*pb.HTTPPath)
+		return v.EnterHTTPPaths(ctx, leftNode, rightNode)
+
+	case *pb.HTTPQuery:
+		rightNode := right.(*pb.HTTPQuery)
+		return v.EnterHTTPQueries(ctx, leftNode, rightNode)
+
+	case *pb.HTTPHeader:
+		rightNode := right.(*pb.HTTPHeader)
+		return v.EnterHTTPHeaders(ctx, leftNode, rightNode)
+
+	case *pb.HTTPCookie:
+		rightNode := right.(*pb.HTTPCookie)
+		return v.EnterHTTPCookies(ctx, leftNode, rightNode)
+
+	case *pb.HTTPBody:
+		rightNode := right.(*pb.HTTPBody)
+		return v.EnterHTTPBodies(ctx, leftNode, rightNode)
+
+	case *pb.HTTPEmpty:
+		rightNode := right.(*pb.HTTPEmpty)
+		return v.EnterHTTPEmpties(ctx, leftNode, rightNode)
+
+	case *pb.HTTPAuth:
+		rightNode := right.(*pb.HTTPAuth)
+		return v.EnterHTTPAuths(ctx, leftNode, rightNode)
+
+	case *pb.HTTPMultipart:
+		rightNode := right.(*pb.HTTPMultipart)
+		return v.EnterHTTPMultiparts(ctx, leftNode, rightNode)
+
+	case *pb.Primitive:
+		rightNode := right.(*pb.Primitive)
+		return v.EnterPrimitives(ctx, leftNode, rightNode)
+	}
+
+	// Didn't understand the type. Just keep going.
+	return keepGoing
+}
+
+// visitChildren implementation for HttpRestSpecPairVisitor.
+func visitPairChildren(cin PairContext, vm PairVisitorManager, left, right interface{}) Cont {
+	visitor := vm.Visitor()
+	v, _ := visitor.(HttpRestSpecPairVisitor)
+	ctx, ok := cin.(HttpRestSpecPairVisitorContext)
+	if !ok {
+		panic(fmt.Sprintf("http_rest.visitPairChildren expected HttpRestSpecPairVisitorContext, got %s",
+			reflect.TypeOf(cin)))
+	}
+
+	// Expect left and right to be the same type.
+	assertSameType(left, right)
+
+	// Dispatch on type and path.
+	switch leftNode := left.(type) {
+	case pb.APISpec, pb.Method, pb.MethodMeta, pb.HTTPMethodMeta, pb.Data, pb.DataMeta, pb.HTTPMeta, pb.HTTPPath, pb.HTTPQuery, pb.HTTPHeader, pb.HTTPCookie, pb.HTTPBody, pb.HTTPAuth, pb.HTTPMultipart, pb.Primitive:
+		// For simplicity, ensure we're operating on a pointer to any complex
+		// structure.
+		return visitPairChildren(ctx, vm, &left, &right)
+
+	case *pb.APISpec:
+		rightNode := right.(*pb.APISpec)
+		return v.VisitAPISpecChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.Method:
+		rightNode := right.(*pb.Method)
+		return v.VisitMethodChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.MethodMeta:
+		rightNode := right.(*pb.MethodMeta)
+		return v.VisitMethodMetaChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPMethodMeta:
+		rightNode := right.(*pb.HTTPMethodMeta)
+		return v.VisitHTTPMethodMetaChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.Data:
+		rightNode := right.(*pb.Data)
+		return v.VisitDataChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.DataMeta:
+		rightNode := right.(*pb.DataMeta)
+		return v.VisitDataMetaChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPPath:
+		rightNode := right.(*pb.HTTPPath)
+		return v.VisitHTTPPathChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPQuery:
+		rightNode := right.(*pb.HTTPQuery)
+		return v.VisitHTTPQueryChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPHeader:
+		rightNode := right.(*pb.HTTPHeader)
+		return v.VisitHTTPHeaderChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPCookie:
+		rightNode := right.(*pb.HTTPCookie)
+		return v.VisitHTTPCookieChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPBody:
+		rightNode := right.(*pb.HTTPBody)
+		return v.VisitHTTPBodyChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPEmpty:
+		rightNode := right.(*pb.HTTPEmpty)
+		return v.VisitHTTPEmptyChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPAuth:
+		rightNode := right.(*pb.HTTPAuth)
+		return v.VisitHTTPAuthChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.HTTPMultipart:
+		rightNode := right.(*pb.HTTPMultipart)
+		return v.VisitHTTPMultipartChildren(ctx, vm, leftNode, rightNode)
+
+	case *pb.Primitive:
+		rightNode := right.(*pb.Primitive)
+		return v.VisitPrimitiveChildren(ctx, vm, leftNode, rightNode)
+
+	default:
+		return v.DefaultVisitChildren(ctx, vm, left, right)
+	}
+}
+
+// leave implementation for HttpRestSpecPairVisitor.
+func leavePair(cin PairContext, visitor interface{}, left, right interface{}, cont Cont) Cont {
+	v, _ := visitor.(HttpRestSpecPairVisitor)
+	ctx, ok := extendPairContext(cin, left, right).(HttpRestSpecPairVisitorContext)
+	if !ok {
+		panic(fmt.Sprintf("http_rest.leave expected HttpRestSpecPairVisitorContext, got %s",
+			reflect.TypeOf(cin)))
+	}
+	keepGoing := cont
+
+	if reflect.TypeOf(left) != reflect.TypeOf(right) {
+		return v.LeaveDifferentTypes(ctx, left, right, cont)
+	}
+
+	// Dispatch on type and path.
+	switch leftNode := left.(type) {
+	case pb.APISpec, pb.Method, pb.MethodMeta, pb.HTTPMethodMeta, pb.Data, pb.DataMeta, pb.HTTPMeta, pb.HTTPPath, pb.HTTPQuery, pb.HTTPHeader, pb.HTTPCookie, pb.HTTPBody, pb.HTTPAuth, pb.HTTPMultipart, pb.Primitive:
+		// For simplicity, ensure we're operating on a pointer to any complex
+		// structure.
+		return leavePair(ctx, v, &left, &right, cont)
+
+	case *pb.APISpec:
+		rightNode := right.(*pb.APISpec)
+		return v.LeaveAPISpecs(ctx, leftNode, rightNode, cont)
+
+	case *pb.Method:
+		rightNode := right.(*pb.Method)
+		return v.LeaveMethods(ctx, leftNode, rightNode, cont)
+
+	case *pb.MethodMeta:
+		rightNode := right.(*pb.MethodMeta)
+		return v.LeaveMethodMetas(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPMethodMeta:
+		rightNode := right.(*pb.HTTPMethodMeta)
+		return v.LeaveHTTPMethodMetas(ctx, leftNode, rightNode, cont)
+
+	case *pb.Data:
+		rightNode := right.(*pb.Data)
+		return v.LeaveData(ctx, leftNode, rightNode, cont)
+
+	case *pb.DataMeta:
+		rightNode := right.(*pb.DataMeta)
+		return v.LeaveDataMetas(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPPath:
+		rightNode := right.(*pb.HTTPPath)
+		return v.LeaveHTTPPaths(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPQuery:
+		rightNode := right.(*pb.HTTPQuery)
+		return v.LeaveHTTPQueries(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPHeader:
+		rightNode := right.(*pb.HTTPHeader)
+		return v.LeaveHTTPHeaders(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPCookie:
+		rightNode := right.(*pb.HTTPCookie)
+		return v.LeaveHTTPCookies(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPBody:
+		rightNode := right.(*pb.HTTPBody)
+		return v.LeaveHTTPBodies(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPEmpty:
+		rightNode := right.(*pb.HTTPEmpty)
+		return v.LeaveHTTPEmpties(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPAuth:
+		rightNode := right.(*pb.HTTPAuth)
+		return v.LeaveHTTPAuths(ctx, leftNode, rightNode, cont)
+
+	case *pb.HTTPMultipart:
+		rightNode := right.(*pb.HTTPMultipart)
+		return v.LeaveHTTPMultiparts(ctx, leftNode, rightNode, cont)
+
+	case *pb.Primitive:
+		rightNode := right.(*pb.Primitive)
+		return v.LeavePrimitives(ctx, leftNode, rightNode, cont)
+	}
+
+	// Didn't understand the type. Just keep going.
+	return keepGoing
+}
+
+// Visits left and right with v in tandem.
+func ApplyPair(v HttpRestSpecPairVisitor, left, right interface{}) Cont {
+	c := new(httpRestSpecPairVisitorContext)
+	vis := NewPairVisitorManager(c, v, enterPair, visitPairChildren, leavePair, extendPairContext)
+	return go_ast_pair.Apply(vis, left, right)
+}
+
+// Panics if the two arguments have different types.
+func assertSameType(x, y interface{}) {
+	xt := reflect.TypeOf(x)
+	yt := reflect.TypeOf(y)
+	if xt != yt {
+		callerName := ""
+		pc, _, _, ok := runtime.Caller(1)
+		details := runtime.FuncForPC(pc)
+		if ok && details != nil {
+			callerName = fmt.Sprintf("%s ", details.Name())
+		}
+		panic(fmt.Sprintf("%sexpected nodes of the same type, but got %s and %s", callerName, xt, yt))
+	}
+}

--- a/visitors/http_rest/http_rest_spec_pair_visitor_context.go
+++ b/visitors/http_rest/http_rest_spec_pair_visitor_context.go
@@ -1,0 +1,121 @@
+package http_rest
+
+import "github.com/akitasoftware/akita-libs/visitors"
+
+// Basically a pair of HttpRestSpecVisitorContexts. See that class for more
+// information.
+type HttpRestSpecPairVisitorContext interface {
+	visitors.PairContext
+
+	ExtendLeftContext(leftNode interface{})
+	ExtendRightContext(rightNode interface{})
+
+	AppendRestPaths(string, string) HttpRestSpecPairVisitorContext
+	GetRestPaths() ([]string, []string)
+	GetRestOperations() (string, string)
+	setRestOperations(string, string)
+	IsArg() (bool, bool)
+	IsResponse() (bool, bool)
+	GetValueTypes() (HttpValueType, HttpValueType)
+	GetArgPaths() ([]string, []string)
+	GetResponsePaths() ([]string, []string)
+	GetEndpointPaths() (string, string)
+	GetHosts() (string, string)
+	setIsArg(bool, bool)
+	setValueType(HttpValueType, HttpValueType)
+	setTopLevelDataIndex(int, int)
+}
+
+type httpRestSpecPairVisitorContext struct {
+	left  *httpRestSpecVisitorContext
+	right *httpRestSpecVisitorContext
+}
+
+func newHttpRestSpecPairVisitorContext() HttpRestSpecPairVisitorContext {
+	return &httpRestSpecPairVisitorContext{
+		left:  &httpRestSpecVisitorContext{},
+		right: &httpRestSpecVisitorContext{},
+	}
+}
+
+func (c *httpRestSpecPairVisitorContext) ExtendLeftContext(leftNode interface{}) {
+	c.left = extendContext(c.left, leftNode).(*httpRestSpecVisitorContext)
+}
+
+func (c *httpRestSpecPairVisitorContext) ExtendRightContext(rightNode interface{}) {
+	c.right = extendContext(c.right, rightNode).(*httpRestSpecVisitorContext)
+}
+
+func (c *httpRestSpecPairVisitorContext) AppendPaths(left, right string) visitors.PairContext {
+	rv := *c
+	rv.left = c.left.AppendPath(left).(*httpRestSpecVisitorContext)
+	rv.right = c.right.AppendPath(right).(*httpRestSpecVisitorContext)
+	return &rv
+}
+
+func (c *httpRestSpecPairVisitorContext) GetPaths() ([]string, []string) {
+	return c.left.GetPath(), c.right.GetPath()
+}
+
+func (c *httpRestSpecPairVisitorContext) AppendRestPaths(left, right string) HttpRestSpecPairVisitorContext {
+	rv := *c
+	rv.left = c.left.AppendRestPath(left).(*httpRestSpecVisitorContext)
+	rv.right = c.right.AppendRestPath(right).(*httpRestSpecVisitorContext)
+	return &rv
+}
+
+func (c *httpRestSpecPairVisitorContext) GetRestPaths() ([]string, []string) {
+	return c.left.GetRestPath(), c.right.GetRestPath()
+}
+
+func (c *httpRestSpecPairVisitorContext) GetRestOperations() (string, string) {
+	return c.left.GetRestOperation(), c.right.GetRestOperation()
+}
+
+func (c *httpRestSpecPairVisitorContext) setRestOperations(left, right string) {
+	c.left.setRestOperation(left)
+	c.right.setRestOperation(right)
+}
+
+func (c *httpRestSpecPairVisitorContext) IsArg() (bool, bool) {
+	return c.left.IsArg(), c.right.IsArg()
+}
+
+func (c *httpRestSpecPairVisitorContext) IsResponse() (bool, bool) {
+	return c.left.IsResponse(), c.right.IsResponse()
+}
+
+func (c *httpRestSpecPairVisitorContext) GetValueTypes() (HttpValueType, HttpValueType) {
+	return c.left.GetValueType(), c.right.GetValueType()
+}
+
+func (c *httpRestSpecPairVisitorContext) GetArgPaths() ([]string, []string) {
+	return c.left.GetArgPath(), c.right.GetArgPath()
+}
+
+func (c *httpRestSpecPairVisitorContext) GetResponsePaths() ([]string, []string) {
+	return c.left.GetResponsePath(), c.right.GetResponsePath()
+}
+
+func (c *httpRestSpecPairVisitorContext) GetEndpointPaths() (string, string) {
+	return c.left.GetEndpointPath(), c.right.GetEndpointPath()
+}
+
+func (c *httpRestSpecPairVisitorContext) GetHosts() (string, string) {
+	return c.left.GetHost(), c.right.GetHost()
+}
+
+func (c *httpRestSpecPairVisitorContext) setIsArg(left, right bool) {
+	c.left.setIsArg(left)
+	c.right.setIsArg(right)
+}
+
+func (c *httpRestSpecPairVisitorContext) setValueType(left, right HttpValueType) {
+	c.left.setValueType(left)
+	c.right.setValueType(right)
+}
+
+func (c *httpRestSpecPairVisitorContext) setTopLevelDataIndex(left, right int) {
+	c.left.setTopLevelDataIndex(left)
+	c.right.setTopLevelDataIndex(right)
+}

--- a/visitors/http_rest/http_rest_spec_visitor.go
+++ b/visitors/http_rest/http_rest_spec_visitor.go
@@ -16,179 +16,297 @@ import (
 // the APISpec message itself.  Returning false stops the traversal.
 type HttpRestSpecVisitor interface {
 	EnterAPISpec(HttpRestSpecVisitorContext, *pb.APISpec) Cont
+	VisitAPISpecChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.APISpec) Cont
 	LeaveAPISpec(HttpRestSpecVisitorContext, *pb.APISpec, Cont) Cont
 
 	EnterMethod(HttpRestSpecVisitorContext, *pb.Method) Cont
+	VisitMethodChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.Method) Cont
 	LeaveMethod(HttpRestSpecVisitorContext, *pb.Method, Cont) Cont
 
 	EnterMethodMeta(HttpRestSpecVisitorContext, *pb.MethodMeta) Cont
+	VisitMethodMetaChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.MethodMeta) Cont
 	LeaveMethodMeta(HttpRestSpecVisitorContext, *pb.MethodMeta, Cont) Cont
 
 	EnterHTTPMethodMeta(HttpRestSpecVisitorContext, *pb.HTTPMethodMeta) Cont
+	VisitHTTPMethodMetaChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPMethodMeta) Cont
 	LeaveHTTPMethodMeta(HttpRestSpecVisitorContext, *pb.HTTPMethodMeta, Cont) Cont
 
 	EnterData(HttpRestSpecVisitorContext, *pb.Data) Cont
+	VisitDataChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.Data) Cont
 	LeaveData(HttpRestSpecVisitorContext, *pb.Data, Cont) Cont
 
 	EnterDataMeta(HttpRestSpecVisitorContext, *pb.DataMeta) Cont
+	VisitDataMetaChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.DataMeta) Cont
 	LeaveDataMeta(HttpRestSpecVisitorContext, *pb.DataMeta, Cont) Cont
 
 	EnterHTTPMeta(HttpRestSpecVisitorContext, *pb.HTTPMeta) Cont
+	VisitHTTPMetaChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPMeta) Cont
 	LeaveHTTPMeta(HttpRestSpecVisitorContext, *pb.HTTPMeta, Cont) Cont
 
 	EnterHTTPPath(HttpRestSpecVisitorContext, *pb.HTTPPath) Cont
+	VisitHTTPPathChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPPath) Cont
 	LeaveHTTPPath(HttpRestSpecVisitorContext, *pb.HTTPPath, Cont) Cont
 
 	EnterHTTPQuery(HttpRestSpecVisitorContext, *pb.HTTPQuery) Cont
+	VisitHTTPQueryChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPQuery) Cont
 	LeaveHTTPQuery(HttpRestSpecVisitorContext, *pb.HTTPQuery, Cont) Cont
 
 	EnterHTTPHeader(HttpRestSpecVisitorContext, *pb.HTTPHeader) Cont
+	VisitHTTPHeaderChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPHeader) Cont
 	LeaveHTTPHeader(HttpRestSpecVisitorContext, *pb.HTTPHeader, Cont) Cont
 
 	EnterHTTPCookie(HttpRestSpecVisitorContext, *pb.HTTPCookie) Cont
+	VisitHTTPCookieChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPCookie) Cont
 	LeaveHTTPCookie(HttpRestSpecVisitorContext, *pb.HTTPCookie, Cont) Cont
 
 	EnterHTTPBody(HttpRestSpecVisitorContext, *pb.HTTPBody) Cont
+	VisitHTTPBodyChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPBody) Cont
 	LeaveHTTPBody(HttpRestSpecVisitorContext, *pb.HTTPBody, Cont) Cont
 
 	EnterHTTPEmpty(HttpRestSpecVisitorContext, *pb.HTTPEmpty) Cont
+	VisitHTTPEmptyChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPEmpty) Cont
 	LeaveHTTPEmpty(HttpRestSpecVisitorContext, *pb.HTTPEmpty, Cont) Cont
 
 	EnterHTTPAuth(HttpRestSpecVisitorContext, *pb.HTTPAuth) Cont
+	VisitHTTPAuthChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPAuth) Cont
 	LeaveHTTPAuth(HttpRestSpecVisitorContext, *pb.HTTPAuth, Cont) Cont
 
 	EnterHTTPMultipart(HttpRestSpecVisitorContext, *pb.HTTPMultipart) Cont
+	VisitHTTPMultipartChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.HTTPMultipart) Cont
 	LeaveHTTPMultipart(HttpRestSpecVisitorContext, *pb.HTTPMultipart, Cont) Cont
 
 	EnterPrimitive(HttpRestSpecVisitorContext, *pb.Primitive) Cont
+	VisitPrimitiveChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.Primitive) Cont
 	LeavePrimitive(HttpRestSpecVisitorContext, *pb.Primitive, Cont) Cont
+
+	DefaultVisitChildren(HttpRestSpecVisitorContext, VisitorManager, interface{}) Cont
 }
 
 // Defines nops for all visitor methods in HttpRestSpecVisitor.
 type DefaultHttpRestSpecVisitor struct{}
 
+func (*DefaultHttpRestSpecVisitor) DefaultVisitChildren(c HttpRestSpecVisitorContext, vm VisitorManager, node interface{}) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, node)
+}
+
+// == APISpec =================================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterAPISpec(c HttpRestSpecVisitorContext, spec *pb.APISpec) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitAPISpecChildren(c HttpRestSpecVisitorContext, vm VisitorManager, spec *pb.APISpec) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, spec)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveAPISpec(c HttpRestSpecVisitorContext, spec *pb.APISpec, cont Cont) Cont {
 	return cont
 }
 
+// == Method ==================================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterMethod(c HttpRestSpecVisitorContext, m *pb.Method) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitMethodChildren(c HttpRestSpecVisitorContext, vm VisitorManager, m *pb.Method) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, m)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveMethod(c HttpRestSpecVisitorContext, m *pb.Method, cont Cont) Cont {
 	return cont
 }
 
+// == MethodMeta ==============================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterMethodMeta(c HttpRestSpecVisitorContext, m *pb.MethodMeta) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitMethodMetaChildren(c HttpRestSpecVisitorContext, vm VisitorManager, m *pb.MethodMeta) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, m)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveMethodMeta(c HttpRestSpecVisitorContext, m *pb.MethodMeta, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPMethodMeta ==========================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPMethodMeta(c HttpRestSpecVisitorContext, m *pb.HTTPMethodMeta) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPMethodMetaChildren(c HttpRestSpecVisitorContext, vm VisitorManager, m *pb.HTTPMethodMeta) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, m)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPMethodMeta(c HttpRestSpecVisitorContext, m *pb.HTTPMethodMeta, cont Cont) Cont {
 	return cont
 }
 
+// == Data =====================================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterData(c HttpRestSpecVisitorContext, d *pb.Data) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitDataChildren(c HttpRestSpecVisitorContext, vm VisitorManager, d *pb.Data) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, d)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveData(c HttpRestSpecVisitorContext, d *pb.Data, cont Cont) Cont {
 	return cont
 }
 
+// == DataMeta ================================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterDataMeta(c HttpRestSpecVisitorContext, d *pb.DataMeta) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitDataMetaChildren(c HttpRestSpecVisitorContext, vm VisitorManager, d *pb.DataMeta) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, d)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveDataMeta(c HttpRestSpecVisitorContext, d *pb.DataMeta, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPMeta ================================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPMeta(c HttpRestSpecVisitorContext, m *pb.HTTPMeta) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPMetaChildren(c HttpRestSpecVisitorContext, vm VisitorManager, m *pb.HTTPMeta) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, m)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPMeta(c HttpRestSpecVisitorContext, m *pb.HTTPMeta, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPPath ================================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPPath(c HttpRestSpecVisitorContext, p *pb.HTTPPath) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPPathChildren(c HttpRestSpecVisitorContext, vm VisitorManager, p *pb.HTTPPath) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, p)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPPath(c HttpRestSpecVisitorContext, p *pb.HTTPPath, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPQuery ===============================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPQuery(c HttpRestSpecVisitorContext, q *pb.HTTPQuery) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPQueryChildren(c HttpRestSpecVisitorContext, vm VisitorManager, q *pb.HTTPQuery) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, q)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPQuery(c HttpRestSpecVisitorContext, q *pb.HTTPQuery, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPHeader ==============================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPHeader(c HttpRestSpecVisitorContext, b *pb.HTTPHeader) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPHeaderChildren(c HttpRestSpecVisitorContext, vm VisitorManager, b *pb.HTTPHeader) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, b)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPHeader(c HttpRestSpecVisitorContext, b *pb.HTTPHeader, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPCookie ==============================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPCookie(c HttpRestSpecVisitorContext, ck *pb.HTTPCookie) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPCookieChildren(c HttpRestSpecVisitorContext, vm VisitorManager, ck *pb.HTTPCookie) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, ck)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPCookie(c HttpRestSpecVisitorContext, ck *pb.HTTPCookie, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPBody ================================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPBody(c HttpRestSpecVisitorContext, b *pb.HTTPBody) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPBodyChildren(c HttpRestSpecVisitorContext, vm VisitorManager, b *pb.HTTPBody) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, b)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPBody(c HttpRestSpecVisitorContext, b *pb.HTTPBody, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPEmpty ===============================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPEmpty(c HttpRestSpecVisitorContext, e *pb.HTTPEmpty) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPEmptyChildren(c HttpRestSpecVisitorContext, vm VisitorManager, e *pb.HTTPEmpty) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, e)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPEmpty(c HttpRestSpecVisitorContext, e *pb.HTTPEmpty, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPAuth ================================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPAuth(c HttpRestSpecVisitorContext, a *pb.HTTPAuth) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPAuthChildren(c HttpRestSpecVisitorContext, vm VisitorManager, a *pb.HTTPAuth) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, a)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPAuth(c HttpRestSpecVisitorContext, a *pb.HTTPAuth, cont Cont) Cont {
 	return cont
 }
 
+// == HTTPMultipart ===========================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterHTTPMultipart(c HttpRestSpecVisitorContext, m *pb.HTTPMultipart) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitHTTPMultipartChildren(c HttpRestSpecVisitorContext, vm VisitorManager, m *pb.HTTPMultipart) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, m)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeaveHTTPMultipart(c HttpRestSpecVisitorContext, m *pb.HTTPMultipart, cont Cont) Cont {
 	return cont
 }
 
+// == Primitive ===============================================================
+
 func (*DefaultHttpRestSpecVisitor) EnterPrimitive(c HttpRestSpecVisitorContext, d *pb.Primitive) Cont {
 	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) VisitPrimitiveChildren(c HttpRestSpecVisitorContext, vm VisitorManager, d *pb.Primitive) Cont {
+	return go_ast.DefaultVisitChildren(c, vm, d)
 }
 
 func (*DefaultHttpRestSpecVisitor) LeavePrimitive(c HttpRestSpecVisitorContext, d *pb.Primitive, cont Cont) Cont {
@@ -201,7 +319,7 @@ func extendContext(cin Context, visitor interface{}, node interface{}) Context {
 	ctx, ok := cin.(HttpRestSpecVisitorContext)
 	result := cin
 	if !ok {
-		panic(fmt.Sprintf("HttpRestSpecVisitor.Visit expected HttpRestSpecVisitorContext, got %s",
+		panic(fmt.Sprintf("http_rest.extendContext expected HttpRestSpecVisitorContext, got %s",
 			reflect.TypeOf(cin)))
 	}
 
@@ -277,7 +395,7 @@ func enter(cin Context, visitor interface{}, node interface{}) Cont {
 	v, _ := visitor.(HttpRestSpecVisitor)
 	ctx, ok := extendContext(cin, visitor, node).(HttpRestSpecVisitorContext)
 	if !ok {
-		panic(fmt.Sprintf("HttpRestSpecVisitor.Visit expected HttpRestSpecVisitorContext, got %s",
+		panic(fmt.Sprintf("http_rest.enter expected HttpRestSpecVisitorContext, got %s",
 			reflect.TypeOf(cin)))
 	}
 	keepGoing := Continue
@@ -325,12 +443,63 @@ func enter(cin Context, visitor interface{}, node interface{}) Cont {
 	return keepGoing
 }
 
+// visitChildren implementation for HttpRestSpecVisitor.
+func visitChildren(cin Context, vm VisitorManager, node interface{}) Cont {
+	visitor := vm.Visitor()
+	v, _ := visitor.(HttpRestSpecVisitor)
+	ctx, ok := cin.(HttpRestSpecVisitorContext)
+	if !ok {
+		panic(fmt.Sprintf("http_rest.visitChildren expected HttpRestSpecVisitorContext, got %s",
+			reflect.TypeOf(cin)))
+	}
+
+	// Dispatch on type and path.
+	switch node := node.(type) {
+	case pb.APISpec, pb.Method, pb.MethodMeta, pb.HTTPMethodMeta, pb.Data, pb.DataMeta, pb.HTTPMeta, pb.HTTPPath, pb.HTTPQuery, pb.HTTPHeader, pb.HTTPCookie, pb.HTTPBody, pb.HTTPAuth, pb.HTTPMultipart, pb.Primitive:
+		// For simplicity, ensure we're operating on a pointer to any complex
+		// structure.
+		return visitChildren(ctx, vm, &node)
+	case *pb.APISpec:
+		return v.VisitAPISpecChildren(ctx, vm, node)
+	case *pb.Method:
+		return v.VisitMethodChildren(ctx, vm, node)
+	case *pb.MethodMeta:
+		return v.VisitMethodMetaChildren(ctx, vm, node)
+	case *pb.HTTPMethodMeta:
+		return v.VisitHTTPMethodMetaChildren(ctx, vm, node)
+	case *pb.Data:
+		return v.VisitDataChildren(ctx, vm, node)
+	case *pb.DataMeta:
+		return v.VisitDataMetaChildren(ctx, vm, node)
+	case *pb.HTTPPath:
+		return v.VisitHTTPPathChildren(ctx, vm, node)
+	case *pb.HTTPQuery:
+		return v.VisitHTTPQueryChildren(ctx, vm, node)
+	case *pb.HTTPHeader:
+		return v.VisitHTTPHeaderChildren(ctx, vm, node)
+	case *pb.HTTPCookie:
+		return v.VisitHTTPCookieChildren(ctx, vm, node)
+	case *pb.HTTPBody:
+		return v.VisitHTTPBodyChildren(ctx, vm, node)
+	case *pb.HTTPEmpty:
+		return v.VisitHTTPEmptyChildren(ctx, vm, node)
+	case *pb.HTTPAuth:
+		return v.VisitHTTPAuthChildren(ctx, vm, node)
+	case *pb.HTTPMultipart:
+		return v.VisitHTTPMultipartChildren(ctx, vm, node)
+	case *pb.Primitive:
+		return v.VisitPrimitiveChildren(ctx, vm, node)
+	default:
+		return v.DefaultVisitChildren(ctx, vm, node)
+	}
+}
+
 // leave implementation for HttpRestSpecVisitor.
 func leave(cin Context, visitor interface{}, node interface{}, cont Cont) Cont {
 	v, _ := visitor.(HttpRestSpecVisitor)
 	ctx, ok := extendContext(cin, visitor, node).(HttpRestSpecVisitorContext)
 	if !ok {
-		panic(fmt.Sprintf("HttpRestSpecVisitor.Visit expected HttpRestSpecVisitorContext, got %s",
+		panic(fmt.Sprintf("http_rest.leave expected HttpRestSpecVisitorContext, got %s",
 			reflect.TypeOf(cin)))
 	}
 	keepGoing := cont
@@ -381,7 +550,7 @@ func leave(cin Context, visitor interface{}, node interface{}, cont Cont) Cont {
 // Visits m with v.
 func Apply(v HttpRestSpecVisitor, m interface{}) Cont {
 	c := new(httpRestSpecVisitorContext)
-	vis := NewVisitorManager(c, v, enter, leave, extendContext)
+	vis := NewVisitorManager(c, v, enter, visitChildren, leave, extendContext)
 	return go_ast.Apply(vis, m)
 }
 

--- a/visitors/http_rest/http_rest_spec_visitor.go
+++ b/visitors/http_rest/http_rest_spec_visitor.go
@@ -8,326 +8,316 @@ import (
 
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 
-	"github.com/akitasoftware/akita-libs/visitors"
+	. "github.com/akitasoftware/akita-libs/visitors"
 	"github.com/akitasoftware/akita-libs/visitors/go_ast"
 )
 
-// Describes which part of an HTTP request/response a value belongs to.
-type HttpValueType int
-
-const (
-	UNKNOWN HttpValueType = iota
-	PATH
-	QUERY
-	HEADER
-	COOKIE
-	BODY
-)
-
-func (t HttpValueType) String() string {
-	return []string{"Unknown", "Path", "Query", "Header", "Cookie", "Body"}[t]
-}
-
-type HttpRestSpecVisitorContext interface {
-	visitors.Context
-
-	// Used by the visitor infrastructure to construct a REST path by replacing
-	// parts of the AST path with names from DataMeta.
-	AppendRestPath(string) HttpRestSpecVisitorContext
-
-	// Gets the REST path, which is similar to the AST path but using names
-	// from DataMeta and MethodMeta objects where appropriate, as well as
-	// hiding names of container data structures.
-	//
-	// For example, the AST path to a path parameter might be:
-	//
-	//   Methods 0 Args arg-headers-0 Value Primitive
-	//
-	// These are the names of the fields in the AST.  In contrast, the REST
-	// path might be:
-	//
-	//   localhost:9000 GET /api/0/issues/{issue_id}/events/ Header Authorization
-	//
-	GetRestPath() []string
-
-	// Returns the REST operation name of the method being traversed, if the
-	// visitor is visiting a method or its descendent nodes.
-	GetRestOperation() string
-	setRestOperation(string)
-
-	// Returns true if the message is a descendent of Method.Args.
-	IsArg() bool
-
-	// Returns true if the message is a descendent of Method.Responses.
-	IsResponse() bool
-
-	GetValueType() HttpValueType
-
-	// Like GetRestPath, except only including the portion about the argument
-	// value.
-	GetArgPath() []string
-
-	// Like GetRestPath, except only including the portion about the argument
-	// value.
-	GetResponsePath() []string
-
-	// Returns the endpoint path, e.g. the "/v1/users" part of
-	// "localhost GET /v1/users".
-	GetEndpointPath() string
-
-	// Returns the host.
-	GetHost() string
-
-	setIsArg(bool)
-	setValueType(HttpValueType)
-	setTopLevelDataIndex(int)
-}
-
-type httpRestSpecVisitorContext struct {
-	path     []string
-	restPath []string
-
-	// nil means we're not sure if this is an arg or response value.
-	isArg *bool
-
-	valueType HttpValueType
-
-	// Index within restPath of the start of the section describing arg or
-	// response.
-	topDataIndex int
-
-	restOperation string
-}
-
-func (c *httpRestSpecVisitorContext) AppendPath(s string) visitors.Context {
-	rv := *c
-	rv.path = append(c.GetPath(), s)
-	return &rv
-}
-
-func (c *httpRestSpecVisitorContext) GetPath() []string {
-	return c.path
-}
-
-func (c *httpRestSpecVisitorContext) AppendRestPath(s string) HttpRestSpecVisitorContext {
-	rv := *c
-	rv.restPath = append(c.GetRestPath(), s)
-	return &rv
-}
-
-func (c *httpRestSpecVisitorContext) GetRestPath() []string {
-	return c.restPath
-}
-
-func (c *httpRestSpecVisitorContext) GetRestOperation() string {
-	return c.restOperation
-}
-
-func (c *httpRestSpecVisitorContext) setRestOperation(op string) {
-	c.restOperation = op
-}
-
-func (c *httpRestSpecVisitorContext) IsArg() bool {
-	if c.isArg != nil {
-		return *c.isArg
-	}
-	return false
-}
-
-func (c *httpRestSpecVisitorContext) IsResponse() bool {
-	if c.isArg != nil {
-		return !*c.isArg
-	}
-	return false
-}
-
-func (c *httpRestSpecVisitorContext) GetValueType() HttpValueType {
-	return c.valueType
-}
-
-func (c *httpRestSpecVisitorContext) GetArgPath() []string {
-	if !c.IsArg() {
-		return nil
-	}
-	return c.getTopLevelDataPath()
-}
-
-func (c *httpRestSpecVisitorContext) GetResponsePath() []string {
-	if !c.IsResponse() {
-		return nil
-	}
-	return c.getTopLevelDataPath()
-}
-
-func (c *httpRestSpecVisitorContext) GetEndpointPath() string {
-	if len(c.restPath) < 3 {
-		return ""
-	}
-	return c.restPath[2]
-}
-
-func (c *httpRestSpecVisitorContext) GetHost() string {
-	if len(c.restPath) < 1 {
-		return ""
-	}
-	return c.restPath[0]
-}
-
-func (c *httpRestSpecVisitorContext) getTopLevelDataPath() []string {
-	p := c.GetRestPath()
-	if len(p) > c.topDataIndex+1 {
-		return p[c.topDataIndex+1:]
-	}
-	return nil
-}
-
-func (c *httpRestSpecVisitorContext) setIsArg(isArg bool) {
-	c.isArg = &isArg
-}
-
-func (c *httpRestSpecVisitorContext) setValueType(vt HttpValueType) {
-	c.valueType = vt
-}
-
-func (c *httpRestSpecVisitorContext) setTopLevelDataIndex(i int) {
-	c.topDataIndex = i
-}
-
-// VisitorManager that lets you read each message in an APISpec, starting with the
-// APISpec message itself.  Returning false stops the traversal.
+// VisitorManager that lets you read each message in an APISpec, starting with
+// the APISpec message itself.  Returning false stops the traversal.
 type HttpRestSpecVisitor interface {
-	VisitAPISpec(HttpRestSpecVisitorContext, *pb.APISpec) bool
-	VisitMethod(HttpRestSpecVisitorContext, *pb.Method) bool
-	VisitData(HttpRestSpecVisitorContext, *pb.Data) bool
-	VisitPrimitive(HttpRestSpecVisitorContext, *pb.Primitive) bool
+	EnterAPISpec(HttpRestSpecVisitorContext, *pb.APISpec) Cont
+	LeaveAPISpec(HttpRestSpecVisitorContext, *pb.APISpec, Cont) Cont
+
+	EnterMethod(HttpRestSpecVisitorContext, *pb.Method) Cont
+	LeaveMethod(HttpRestSpecVisitorContext, *pb.Method, Cont) Cont
+
+	EnterMethodMeta(HttpRestSpecVisitorContext, *pb.MethodMeta) Cont
+	LeaveMethodMeta(HttpRestSpecVisitorContext, *pb.MethodMeta, Cont) Cont
+
+	EnterHTTPMethodMeta(HttpRestSpecVisitorContext, *pb.HTTPMethodMeta) Cont
+	LeaveHTTPMethodMeta(HttpRestSpecVisitorContext, *pb.HTTPMethodMeta, Cont) Cont
+
+	EnterData(HttpRestSpecVisitorContext, *pb.Data) Cont
+	LeaveData(HttpRestSpecVisitorContext, *pb.Data, Cont) Cont
+
+	EnterDataMeta(HttpRestSpecVisitorContext, *pb.DataMeta) Cont
+	LeaveDataMeta(HttpRestSpecVisitorContext, *pb.DataMeta, Cont) Cont
+
+	EnterHTTPMeta(HttpRestSpecVisitorContext, *pb.HTTPMeta) Cont
+	LeaveHTTPMeta(HttpRestSpecVisitorContext, *pb.HTTPMeta, Cont) Cont
+
+	EnterHTTPPath(HttpRestSpecVisitorContext, *pb.HTTPPath) Cont
+	LeaveHTTPPath(HttpRestSpecVisitorContext, *pb.HTTPPath, Cont) Cont
+
+	EnterHTTPQuery(HttpRestSpecVisitorContext, *pb.HTTPQuery) Cont
+	LeaveHTTPQuery(HttpRestSpecVisitorContext, *pb.HTTPQuery, Cont) Cont
+
+	EnterHTTPHeader(HttpRestSpecVisitorContext, *pb.HTTPHeader) Cont
+	LeaveHTTPHeader(HttpRestSpecVisitorContext, *pb.HTTPHeader, Cont) Cont
+
+	EnterHTTPCookie(HttpRestSpecVisitorContext, *pb.HTTPCookie) Cont
+	LeaveHTTPCookie(HttpRestSpecVisitorContext, *pb.HTTPCookie, Cont) Cont
+
+	EnterHTTPBody(HttpRestSpecVisitorContext, *pb.HTTPBody) Cont
+	LeaveHTTPBody(HttpRestSpecVisitorContext, *pb.HTTPBody, Cont) Cont
+
+	EnterHTTPEmpty(HttpRestSpecVisitorContext, *pb.HTTPEmpty) Cont
+	LeaveHTTPEmpty(HttpRestSpecVisitorContext, *pb.HTTPEmpty, Cont) Cont
+
+	EnterHTTPAuth(HttpRestSpecVisitorContext, *pb.HTTPAuth) Cont
+	LeaveHTTPAuth(HttpRestSpecVisitorContext, *pb.HTTPAuth, Cont) Cont
+
+	EnterHTTPMultipart(HttpRestSpecVisitorContext, *pb.HTTPMultipart) Cont
+	LeaveHTTPMultipart(HttpRestSpecVisitorContext, *pb.HTTPMultipart, Cont) Cont
+
+	EnterPrimitive(HttpRestSpecVisitorContext, *pb.Primitive) Cont
+	LeavePrimitive(HttpRestSpecVisitorContext, *pb.Primitive, Cont) Cont
 }
 
 // Defines nops for all visitor methods in HttpRestSpecVisitor.
 type DefaultHttpRestSpecVisitor struct{}
 
-func (*DefaultHttpRestSpecVisitor) VisitAPISpec(c HttpRestSpecVisitorContext, spec *pb.APISpec) bool {
-	return true
+func (*DefaultHttpRestSpecVisitor) EnterAPISpec(c HttpRestSpecVisitorContext, spec *pb.APISpec) Cont {
+	return Continue
 }
 
-func (*DefaultHttpRestSpecVisitor) VisitMethod(c HttpRestSpecVisitorContext, m *pb.Method) bool {
-	return true
+func (*DefaultHttpRestSpecVisitor) LeaveAPISpec(c HttpRestSpecVisitorContext, spec *pb.APISpec, cont Cont) Cont {
+	return cont
 }
 
-func (*DefaultHttpRestSpecVisitor) VisitData(c HttpRestSpecVisitorContext, d *pb.Data) bool {
-	return true
+func (*DefaultHttpRestSpecVisitor) EnterMethod(c HttpRestSpecVisitorContext, m *pb.Method) Cont {
+	return Continue
 }
 
-func (*DefaultHttpRestSpecVisitor) VisitPrimitive(c HttpRestSpecVisitorContext, d *pb.Primitive) bool {
-	return true
+func (*DefaultHttpRestSpecVisitor) LeaveMethod(c HttpRestSpecVisitorContext, m *pb.Method, cont Cont) Cont {
+	return cont
 }
 
-func extendContext(cin visitors.Context, rin interface{}, x interface{}) visitors.Context {
-	r, ok := rin.(HttpRestSpecVisitor)
-	c, ok := cin.(HttpRestSpecVisitorContext)
-	rc := cin
+func (*DefaultHttpRestSpecVisitor) EnterMethodMeta(c HttpRestSpecVisitorContext, m *pb.MethodMeta) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveMethodMeta(c HttpRestSpecVisitorContext, m *pb.MethodMeta, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPMethodMeta(c HttpRestSpecVisitorContext, m *pb.HTTPMethodMeta) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPMethodMeta(c HttpRestSpecVisitorContext, m *pb.HTTPMethodMeta, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterData(c HttpRestSpecVisitorContext, d *pb.Data) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveData(c HttpRestSpecVisitorContext, d *pb.Data, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterDataMeta(c HttpRestSpecVisitorContext, d *pb.DataMeta) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveDataMeta(c HttpRestSpecVisitorContext, d *pb.DataMeta, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPMeta(c HttpRestSpecVisitorContext, m *pb.HTTPMeta) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPMeta(c HttpRestSpecVisitorContext, m *pb.HTTPMeta, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPPath(c HttpRestSpecVisitorContext, p *pb.HTTPPath) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPPath(c HttpRestSpecVisitorContext, p *pb.HTTPPath, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPQuery(c HttpRestSpecVisitorContext, q *pb.HTTPQuery) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPQuery(c HttpRestSpecVisitorContext, q *pb.HTTPQuery, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPHeader(c HttpRestSpecVisitorContext, b *pb.HTTPHeader) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPHeader(c HttpRestSpecVisitorContext, b *pb.HTTPHeader, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPCookie(c HttpRestSpecVisitorContext, ck *pb.HTTPCookie) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPCookie(c HttpRestSpecVisitorContext, ck *pb.HTTPCookie, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPBody(c HttpRestSpecVisitorContext, b *pb.HTTPBody) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPBody(c HttpRestSpecVisitorContext, b *pb.HTTPBody, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPEmpty(c HttpRestSpecVisitorContext, e *pb.HTTPEmpty) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPEmpty(c HttpRestSpecVisitorContext, e *pb.HTTPEmpty, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPAuth(c HttpRestSpecVisitorContext, a *pb.HTTPAuth) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPAuth(c HttpRestSpecVisitorContext, a *pb.HTTPAuth, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterHTTPMultipart(c HttpRestSpecVisitorContext, m *pb.HTTPMultipart) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeaveHTTPMultipart(c HttpRestSpecVisitorContext, m *pb.HTTPMultipart, cont Cont) Cont {
+	return cont
+}
+
+func (*DefaultHttpRestSpecVisitor) EnterPrimitive(c HttpRestSpecVisitorContext, d *pb.Primitive) Cont {
+	return Continue
+}
+
+func (*DefaultHttpRestSpecVisitor) LeavePrimitive(c HttpRestSpecVisitorContext, d *pb.Primitive, cont Cont) Cont {
+	return cont
+}
+
+// extendContext implementation for HttpRestSpecVisitor.
+func extendContext(cin Context, visitor interface{}, node interface{}) Context {
+	v, _ := visitor.(HttpRestSpecVisitor)
+	ctx, ok := cin.(HttpRestSpecVisitorContext)
+	result := cin
 	if !ok {
 		panic(fmt.Sprintf("HttpRestSpecVisitor.Visit expected HttpRestSpecVisitorContext, got %s",
 			reflect.TypeOf(cin)))
 	}
 
 	// Dispatch on type and path.
-	switch x.(type) {
+	switch node := node.(type) {
 	case pb.APISpec, pb.Method, pb.Data, pb.Primitive:
 		// For simplicity, ensure we're operating on a pointer to any complex
 		// structure.
-		rc = extendContext(c, r, &x)
+		result = extendContext(ctx, v, &node)
 	case *pb.Method:
-		m, _ := x.(*pb.Method)
-
 		// Update the RestPath in the context
-		meta := m.GetMeta().GetHttp()
+		meta := node.GetMeta().GetHttp()
 		if meta != nil {
-			c.setRestOperation(meta.GetMethod())
-			c = c.AppendRestPath(meta.GetHost()).AppendRestPath(meta.GetMethod()).AppendRestPath(meta.GetPathTemplate())
-			rc = c
+			ctx.setRestOperation(meta.GetMethod())
+			ctx = ctx.AppendRestPath(meta.GetHost()).AppendRestPath(meta.GetMethod()).AppendRestPath(meta.GetPathTemplate())
+			result = ctx
 		}
 	case *pb.Data:
-		d, _ := x.(*pb.Data)
-
 		// Update the RestPath in the context
 		// HTTPMeta is only valid for the top-level Data object.
-		if d.GetMeta() != nil && d.GetMeta().GetHttp() != nil {
-			c.setTopLevelDataIndex(len(c.GetRestPath()) - 1)
+		if node.GetMeta() != nil && node.GetMeta().GetHttp() != nil {
+			ctx.setTopLevelDataIndex(len(ctx.GetRestPath()) - 1)
 
-			meta := d.GetMeta().GetHttp()
+			meta := node.GetMeta().GetHttp()
 			switch rc := meta.GetResponseCode(); rc {
 			case 0: // arg
-				c.setIsArg(true)
-				c = c.AppendRestPath("Arg")
+				ctx.setIsArg(true)
+				ctx = ctx.AppendRestPath("Arg")
 			default:
-				c.setIsArg(false)
-				c = c.AppendRestPath("Response")
+				ctx.setIsArg(false)
+				ctx = ctx.AppendRestPath("Response")
 				if rc == -1 {
-					c = c.AppendRestPath("default")
+					ctx = ctx.AppendRestPath("default")
 				} else {
-					c = c.AppendRestPath(strconv.Itoa(int(rc)))
+					ctx = ctx.AppendRestPath(strconv.Itoa(int(rc)))
 				}
 			}
 
 			var valueKey string
 			if x := meta.GetPath(); x != nil {
-				c.setValueType(PATH)
+				ctx.setValueType(PATH)
 				valueKey = x.GetKey()
 			} else if x := meta.GetQuery(); x != nil {
-				c.setValueType(QUERY)
+				ctx.setValueType(QUERY)
 				valueKey = x.GetKey()
 			} else if x := meta.GetHeader(); x != nil {
-				c.setValueType(HEADER)
+				ctx.setValueType(HEADER)
 				valueKey = x.GetKey()
 			} else if x := meta.GetCookie(); x != nil {
-				c.setValueType(COOKIE)
+				ctx.setValueType(COOKIE)
 				valueKey = x.GetKey()
 			} else if x := meta.GetBody(); x != nil {
-				c.setValueType(BODY)
+				ctx.setValueType(BODY)
 				valueKey = x.GetContentType().String()
 			}
 
-			c = c.AppendRestPath(c.GetValueType().String())
-			c = c.AppendRestPath(valueKey)
+			ctx = ctx.AppendRestPath(ctx.GetValueType().String())
+			ctx = ctx.AppendRestPath(valueKey)
 
 			// Do nothing for HTTPEmpty
 		} else {
-			astPath := c.GetPath()
-			c = c.AppendRestPath(astPath[len(astPath)-1])
+			astPath := ctx.GetPath()
+			ctx = ctx.AppendRestPath(astPath[len(astPath)-1])
 		}
-		rc = c
+		result = ctx
 	}
 
-	return rc
+	return result
 }
 
-func visit(cin visitors.Context, rin interface{}, x interface{}) bool {
-	r, ok := rin.(HttpRestSpecVisitor)
-	c, ok := extendContext(cin, rin, x).(HttpRestSpecVisitorContext)
+// enter implementation for HttpRestSpecVisitor.
+func enter(cin Context, visitor interface{}, node interface{}) Cont {
+	v, _ := visitor.(HttpRestSpecVisitor)
+	ctx, ok := extendContext(cin, visitor, node).(HttpRestSpecVisitorContext)
 	if !ok {
 		panic(fmt.Sprintf("HttpRestSpecVisitor.Visit expected HttpRestSpecVisitorContext, got %s",
 			reflect.TypeOf(cin)))
 	}
-	keepGoing := true
+	keepGoing := Continue
 
 	// Dispatch on type and path.
-	switch x.(type) {
-	case pb.APISpec, pb.Method, pb.Data, pb.Primitive:
+	switch node := node.(type) {
+	case pb.APISpec, pb.Method, pb.MethodMeta, pb.HTTPMethodMeta, pb.Data, pb.DataMeta, pb.HTTPMeta, pb.HTTPPath, pb.HTTPQuery, pb.HTTPHeader, pb.HTTPCookie, pb.HTTPBody, pb.HTTPAuth, pb.HTTPMultipart, pb.Primitive:
 		// For simplicity, ensure we're operating on a pointer to any complex
 		// structure.
-		keepGoing = visit(c, r, &x)
+		keepGoing = enter(ctx, v, &node)
 	case *pb.APISpec:
-		s, _ := x.(*pb.APISpec)
-		keepGoing = r.VisitAPISpec(c, s)
+		keepGoing = v.EnterAPISpec(ctx, node)
 	case *pb.Method:
-		m, _ := x.(*pb.Method)
-		keepGoing = r.VisitMethod(c, m)
+		keepGoing = v.EnterMethod(ctx, node)
+	case *pb.MethodMeta:
+		keepGoing = v.EnterMethodMeta(ctx, node)
+	case *pb.HTTPMethodMeta:
+		keepGoing = v.EnterHTTPMethodMeta(ctx, node)
 	case *pb.Data:
-		d, _ := x.(*pb.Data)
-		keepGoing = r.VisitData(c, d)
+		keepGoing = v.EnterData(ctx, node)
+	case *pb.DataMeta:
+		keepGoing = v.EnterDataMeta(ctx, node)
+	case *pb.HTTPPath:
+		keepGoing = v.EnterHTTPPath(ctx, node)
+	case *pb.HTTPQuery:
+		keepGoing = v.EnterHTTPQuery(ctx, node)
+	case *pb.HTTPHeader:
+		keepGoing = v.EnterHTTPHeader(ctx, node)
+	case *pb.HTTPCookie:
+		keepGoing = v.EnterHTTPCookie(ctx, node)
+	case *pb.HTTPBody:
+		keepGoing = v.EnterHTTPBody(ctx, node)
+	case *pb.HTTPEmpty:
+		keepGoing = v.EnterHTTPEmpty(ctx, node)
+	case *pb.HTTPAuth:
+		keepGoing = v.EnterHTTPAuth(ctx, node)
+	case *pb.HTTPMultipart:
+		keepGoing = v.EnterHTTPMultipart(ctx, node)
 	case *pb.Primitive:
-		p, _ := x.(*pb.Primitive)
-		keepGoing = r.VisitPrimitive(c, p)
+		keepGoing = v.EnterPrimitive(ctx, node)
 	default:
 		// Just keep going if we don't understand the type.
 	}
@@ -335,12 +325,64 @@ func visit(cin visitors.Context, rin interface{}, x interface{}) bool {
 	return keepGoing
 }
 
-// Visits m with v.  Returns false if the visitor aborts traversal (by
-// returning false).  Order is either PREORDER or POSTORDER.
-func Apply(order go_ast.TraversalOrder, v HttpRestSpecVisitor, m interface{}) bool {
+// leave implementation for HttpRestSpecVisitor.
+func leave(cin Context, visitor interface{}, node interface{}, cont Cont) Cont {
+	v, _ := visitor.(HttpRestSpecVisitor)
+	ctx, ok := extendContext(cin, visitor, node).(HttpRestSpecVisitorContext)
+	if !ok {
+		panic(fmt.Sprintf("HttpRestSpecVisitor.Visit expected HttpRestSpecVisitorContext, got %s",
+			reflect.TypeOf(cin)))
+	}
+	keepGoing := cont
+
+	// Dispatch on type and path.
+	switch node := node.(type) {
+	case pb.APISpec, pb.Method, pb.MethodMeta, pb.HTTPMethodMeta, pb.Data, pb.DataMeta, pb.HTTPMeta, pb.HTTPPath, pb.HTTPQuery, pb.HTTPHeader, pb.HTTPCookie, pb.HTTPBody, pb.HTTPAuth, pb.HTTPMultipart, pb.Primitive:
+		// For simplicity, ensure we're operating on a pointer to any complex
+		// structure.
+		keepGoing = leave(ctx, v, &node, cont)
+	case *pb.APISpec:
+		keepGoing = v.LeaveAPISpec(ctx, node, cont)
+	case *pb.Method:
+		keepGoing = v.LeaveMethod(ctx, node, cont)
+	case *pb.MethodMeta:
+		keepGoing = v.LeaveMethodMeta(ctx, node, cont)
+	case *pb.HTTPMethodMeta:
+		keepGoing = v.LeaveHTTPMethodMeta(ctx, node, cont)
+	case *pb.Data:
+		keepGoing = v.LeaveData(ctx, node, cont)
+	case *pb.DataMeta:
+		keepGoing = v.LeaveDataMeta(ctx, node, cont)
+	case *pb.HTTPPath:
+		keepGoing = v.LeaveHTTPPath(ctx, node, cont)
+	case *pb.HTTPQuery:
+		keepGoing = v.LeaveHTTPQuery(ctx, node, cont)
+	case *pb.HTTPHeader:
+		keepGoing = v.LeaveHTTPHeader(ctx, node, cont)
+	case *pb.HTTPCookie:
+		keepGoing = v.LeaveHTTPCookie(ctx, node, cont)
+	case *pb.HTTPBody:
+		keepGoing = v.LeaveHTTPBody(ctx, node, cont)
+	case *pb.HTTPEmpty:
+		keepGoing = v.LeaveHTTPEmpty(ctx, node, cont)
+	case *pb.HTTPAuth:
+		keepGoing = v.LeaveHTTPAuth(ctx, node, cont)
+	case *pb.HTTPMultipart:
+		keepGoing = v.LeaveHTTPMultipart(ctx, node, cont)
+	case *pb.Primitive:
+		keepGoing = v.LeavePrimitive(ctx, node, cont)
+	default:
+		// Just keep going if we don't understand the type.
+	}
+
+	return keepGoing
+}
+
+// Visits m with v.
+func Apply(v HttpRestSpecVisitor, m interface{}) Cont {
 	c := new(httpRestSpecVisitorContext)
-	vis := visitors.NewVisitorManager(c, v, visit, extendContext)
-	return go_ast.Apply(order, vis, m)
+	vis := NewVisitorManager(c, v, enter, leave, extendContext)
+	return go_ast.Apply(vis, m)
 }
 
 func GetPrimitiveType(p *pb.Primitive) reflect.Type {
@@ -395,12 +437,12 @@ type PrintVisitor struct {
 	DefaultHttpRestSpecVisitor
 }
 
-func (*PrintVisitor) VisitData(ctx HttpRestSpecVisitorContext, d *pb.Data) bool {
+func (*PrintVisitor) EnterData(ctx HttpRestSpecVisitorContext, d *pb.Data) Cont {
 	fmt.Printf("%s %s\n", strings.Join(ctx.GetRestPath(), "."), d)
-	return true
+	return Continue
 }
 
-func (*PrintVisitor) VisitPrimitive(ctx HttpRestSpecVisitorContext, p *pb.Primitive) bool {
+func (*PrintVisitor) EnterPrimitive(ctx HttpRestSpecVisitorContext, p *pb.Primitive) Cont {
 	fmt.Printf("%s %s (%s)\n", strings.Join(ctx.GetRestPath(), "."), GetPrimitiveValue(p), GetPrimitiveType(p))
-	return true
+	return Continue
 }

--- a/visitors/http_rest/http_rest_spec_visitor.go
+++ b/visitors/http_rest/http_rest_spec_visitor.go
@@ -13,7 +13,7 @@ import (
 )
 
 // VisitorManager that lets you read each message in an APISpec, starting with
-// the APISpec message itself.  Returning false stops the traversal.
+// the APISpec message itself.
 type HttpRestSpecVisitor interface {
 	EnterAPISpec(HttpRestSpecVisitorContext, *pb.APISpec) Cont
 	VisitAPISpecChildren(HttpRestSpecVisitorContext, VisitorManager, *pb.APISpec) Cont
@@ -314,8 +314,7 @@ func (*DefaultHttpRestSpecVisitor) LeavePrimitive(c HttpRestSpecVisitorContext, 
 }
 
 // extendContext implementation for HttpRestSpecVisitor.
-func extendContext(cin Context, visitor interface{}, node interface{}) Context {
-	v, _ := visitor.(HttpRestSpecVisitor)
+func extendContext(cin Context, node interface{}) Context {
 	ctx, ok := cin.(HttpRestSpecVisitorContext)
 	result := cin
 	if !ok {
@@ -328,7 +327,7 @@ func extendContext(cin Context, visitor interface{}, node interface{}) Context {
 	case pb.APISpec, pb.Method, pb.Data, pb.Primitive:
 		// For simplicity, ensure we're operating on a pointer to any complex
 		// structure.
-		result = extendContext(ctx, v, &node)
+		result = extendContext(ctx, &node)
 	case *pb.Method:
 		// Update the RestPath in the context
 		meta := node.GetMeta().GetHttp()
@@ -393,7 +392,7 @@ func extendContext(cin Context, visitor interface{}, node interface{}) Context {
 // enter implementation for HttpRestSpecVisitor.
 func enter(cin Context, visitor interface{}, node interface{}) Cont {
 	v, _ := visitor.(HttpRestSpecVisitor)
-	ctx, ok := extendContext(cin, visitor, node).(HttpRestSpecVisitorContext)
+	ctx, ok := extendContext(cin, node).(HttpRestSpecVisitorContext)
 	if !ok {
 		panic(fmt.Sprintf("http_rest.enter expected HttpRestSpecVisitorContext, got %s",
 			reflect.TypeOf(cin)))
@@ -497,7 +496,7 @@ func visitChildren(cin Context, vm VisitorManager, node interface{}) Cont {
 // leave implementation for HttpRestSpecVisitor.
 func leave(cin Context, visitor interface{}, node interface{}, cont Cont) Cont {
 	v, _ := visitor.(HttpRestSpecVisitor)
-	ctx, ok := extendContext(cin, visitor, node).(HttpRestSpecVisitorContext)
+	ctx, ok := extendContext(cin, node).(HttpRestSpecVisitorContext)
 	if !ok {
 		panic(fmt.Sprintf("http_rest.leave expected HttpRestSpecVisitorContext, got %s",
 			reflect.TypeOf(cin)))

--- a/visitors/http_rest/http_rest_spec_visitor_context.go
+++ b/visitors/http_rest/http_rest_spec_visitor_context.go
@@ -1,0 +1,184 @@
+package http_rest
+
+import "github.com/akitasoftware/akita-libs/visitors"
+
+// Describes which part of an HTTP request/response a value belongs to.
+type HttpValueType int
+
+const (
+	UNKNOWN HttpValueType = iota
+	PATH
+	QUERY
+	HEADER
+	COOKIE
+	BODY
+)
+
+func (t HttpValueType) String() string {
+	return []string{"Unknown", "Path", "Query", "Header", "Cookie", "Body"}[t]
+}
+
+type HttpRestSpecVisitorContext interface {
+	visitors.Context
+
+	// Used by the visitor infrastructure to construct a REST path by replacing
+	// parts of the AST path with names from DataMeta.
+	AppendRestPath(string) HttpRestSpecVisitorContext
+
+	// Gets the REST path, which is similar to the AST path but using names
+	// from DataMeta and MethodMeta objects where appropriate, as well as
+	// hiding names of container data structures.
+	//
+	// For example, the AST path to a path parameter might be:
+	//
+	//   Methods 0 Args arg-headers-0 Value Primitive
+	//
+	// These are the names of the fields in the AST.  In contrast, the REST
+	// path might be:
+	//
+	//   localhost:9000 GET /api/0/issues/{issue_id}/events/ Header Authorization
+	//
+	GetRestPath() []string
+
+	// Returns the REST operation name of the method being traversed, if the
+	// visitor is visiting a method or its descendent nodes.
+	GetRestOperation() string
+	setRestOperation(string)
+
+	// Returns true if the message is a descendent of Method.Args.
+	IsArg() bool
+
+	// Returns true if the message is a descendent of Method.Responses.
+	IsResponse() bool
+
+	GetValueType() HttpValueType
+
+	// Like GetRestPath, except only including the portion about the argument
+	// value.
+	GetArgPath() []string
+
+	// Like GetRestPath, except only including the portion about the argument
+	// value.
+	GetResponsePath() []string
+
+	// Returns the endpoint path, e.g. the "/v1/users" part of
+	// "localhost GET /v1/users".
+	GetEndpointPath() string
+
+	// Returns the host.
+	GetHost() string
+
+	setIsArg(bool)
+	setValueType(HttpValueType)
+	setTopLevelDataIndex(int)
+}
+
+type httpRestSpecVisitorContext struct {
+	path     []string
+	restPath []string
+
+	// nil means we're not sure if this is an arg or response value.
+	isArg *bool
+
+	valueType HttpValueType
+
+	// Index within restPath of the start of the section describing arg or
+	// response.
+	topDataIndex int
+
+	restOperation string
+}
+
+func (c *httpRestSpecVisitorContext) AppendPath(s string) visitors.Context {
+	rv := *c
+	rv.path = append(c.GetPath(), s)
+	return &rv
+}
+
+func (c *httpRestSpecVisitorContext) GetPath() []string {
+	return c.path
+}
+
+func (c *httpRestSpecVisitorContext) AppendRestPath(s string) HttpRestSpecVisitorContext {
+	rv := *c
+	rv.restPath = append(c.GetRestPath(), s)
+	return &rv
+}
+
+func (c *httpRestSpecVisitorContext) GetRestPath() []string {
+	return c.restPath
+}
+
+func (c *httpRestSpecVisitorContext) GetRestOperation() string {
+	return c.restOperation
+}
+
+func (c *httpRestSpecVisitorContext) setRestOperation(op string) {
+	c.restOperation = op
+}
+
+func (c *httpRestSpecVisitorContext) IsArg() bool {
+	if c.isArg != nil {
+		return *c.isArg
+	}
+	return false
+}
+
+func (c *httpRestSpecVisitorContext) IsResponse() bool {
+	if c.isArg != nil {
+		return !*c.isArg
+	}
+	return false
+}
+
+func (c *httpRestSpecVisitorContext) GetValueType() HttpValueType {
+	return c.valueType
+}
+
+func (c *httpRestSpecVisitorContext) GetArgPath() []string {
+	if !c.IsArg() {
+		return nil
+	}
+	return c.getTopLevelDataPath()
+}
+
+func (c *httpRestSpecVisitorContext) GetResponsePath() []string {
+	if !c.IsResponse() {
+		return nil
+	}
+	return c.getTopLevelDataPath()
+}
+
+func (c *httpRestSpecVisitorContext) GetEndpointPath() string {
+	if len(c.restPath) < 3 {
+		return ""
+	}
+	return c.restPath[2]
+}
+
+func (c *httpRestSpecVisitorContext) GetHost() string {
+	if len(c.restPath) < 1 {
+		return ""
+	}
+	return c.restPath[0]
+}
+
+func (c *httpRestSpecVisitorContext) getTopLevelDataPath() []string {
+	p := c.GetRestPath()
+	if len(p) > c.topDataIndex+1 {
+		return p[c.topDataIndex+1:]
+	}
+	return nil
+}
+
+func (c *httpRestSpecVisitorContext) setIsArg(isArg bool) {
+	c.isArg = &isArg
+}
+
+func (c *httpRestSpecVisitorContext) setValueType(vt HttpValueType) {
+	c.valueType = vt
+}
+
+func (c *httpRestSpecVisitorContext) setTopLevelDataIndex(i int) {
+	c.topDataIndex = i
+}

--- a/visitors/pair_visitor.go
+++ b/visitors/pair_visitor.go
@@ -1,0 +1,112 @@
+package visitors
+
+type PairContext interface {
+	// Returns a new Context after appending to the paths.
+	AppendPaths(left string, right string) PairContext
+
+	// Returns the paths through the structures being traversed.
+	// See Context.GetPath().
+	GetPaths() ([]string, []string)
+}
+
+func NewPairContext() PairContext {
+	return &pairContext{
+		left:  NewContext(),
+		right: NewContext(),
+	}
+}
+
+// A version of VisitorManager that traverses a pair of nodes in tandem.
+type PairVisitorManager interface {
+	// Creates an empty context.
+	Context() PairContext
+
+	// Returns the visitor implementation.
+	Visitor() interface{}
+
+	// Provides functionality for entering a pair of nodes, before visiting the
+	// nodes' children.
+	EnterNodes(c PairContext, visitor interface{}, leftNode, rightNode interface{}) Cont
+
+	// Visits the nodes' children with the given context.
+	VisitChildren(c PairContext, vm PairVisitorManager, leftNode, rightNode interface{}) Cont
+
+	// Provides functionality for leaving a pair of nodes, after visiting the
+	// nodes' children.
+	//
+	// The given cont can be Continue, Stop, or SkipChildren, indicating the
+	// state of the traversal before leaving the node. Most implementations will
+	// want to return this value unchanged: for convenience, if SkipChildren is
+	// returned, the visitor framework will interpret this as Continue.
+	LeaveNodes(c PairContext, visitor interface{}, leftNode, rightNode interface{}, cont Cont) Cont
+
+	ExtendContext(c PairContext, leftNode, rightNode interface{}) PairContext
+}
+
+func NewPairVisitorManager(
+	c PairContext,
+	v interface{},
+	enter func(c PairContext, visitor interface{}, left, right interface{}) Cont,
+	visitChildren func(c PairContext, vm PairVisitorManager, left, right interface{}) Cont,
+	leave func(c PairContext, visitor interface{}, left, right interface{}, cont Cont) Cont,
+	extendContext func(c PairContext, left, right interface{}) PairContext,
+) PairVisitorManager {
+	rv := pairVisitor{
+		context:       c,
+		visitor:       v,
+		enter:         enter,
+		visitChildren: visitChildren,
+		leave:         leave,
+		extendContext: extendContext,
+	}
+	return &rv
+}
+
+type pairContext struct {
+	left  Context
+	right Context
+}
+
+func (c *pairContext) AppendPaths(left string, right string) PairContext {
+	return &pairContext{
+		left:  c.left.AppendPath(left),
+		right: c.right.AppendPath(right),
+	}
+}
+
+func (c *pairContext) GetPaths() ([]string, []string) {
+	return c.left.GetPath(), c.right.GetPath()
+}
+
+type pairVisitor struct {
+	context       PairContext
+	visitor       interface{}
+	enter         func(c PairContext, visitor interface{}, left, right interface{}) Cont
+	visitChildren func(c PairContext, vm PairVisitorManager, left, right interface{}) Cont
+	leave         func(c PairContext, visitor interface{}, left, right interface{}, cont Cont) Cont
+	extendContext func(c PairContext, left, right interface{}) PairContext
+}
+
+func (v *pairVisitor) Context() PairContext {
+	return v.context
+}
+
+func (v *pairVisitor) Visitor() interface{} {
+	return v.visitor
+}
+
+func (v *pairVisitor) EnterNodes(c PairContext, visitor interface{}, left, right interface{}) Cont {
+	return v.enter(c, visitor, left, right)
+}
+
+func (v *pairVisitor) VisitChildren(c PairContext, vm PairVisitorManager, left, right interface{}) Cont {
+	return v.visitChildren(c, vm, left, right)
+}
+
+func (v *pairVisitor) LeaveNodes(c PairContext, visitor interface{}, left, right interface{}, cont Cont) Cont {
+	return v.leave(c, visitor, left, right, cont)
+}
+
+func (v *pairVisitor) ExtendContext(c PairContext, left, right interface{}) PairContext {
+	return v.extendContext(c, left, right)
+}

--- a/visitors/visitor.go
+++ b/visitors/visitor.go
@@ -104,7 +104,7 @@ func NewVisitorManager(
 	enter func(c Context, visitor interface{}, term interface{}) Cont,
 	visitChildren func(c Context, vm VisitorManager, term interface{}) Cont,
 	leave func(c Context, visitor interface{}, term interface{}, cont Cont) Cont,
-	extendContext func(c Context, visitor interface{}, term interface{}) Context,
+	extendContext func(c Context, term interface{}) Context,
 ) VisitorManager {
 	rv := visitor{
 		context:       c,
@@ -135,7 +135,7 @@ type visitor struct {
 	enter         func(c Context, visitor interface{}, term interface{}) Cont
 	visitChildren func(c Context, vm VisitorManager, term interface{}) Cont
 	leave         func(c Context, visitor interface{}, term interface{}, cont Cont) Cont
-	extendContext func(c Context, visitor interface{}, term interface{}) Context
+	extendContext func(c Context, term interface{}) Context
 }
 
 func (v *visitor) Context() Context {
@@ -159,5 +159,5 @@ func (v *visitor) LeaveNode(c Context, visitor interface{}, term interface{}, co
 }
 
 func (v *visitor) ExtendContext(c Context, visitor interface{}, term interface{}) Context {
-	return v.extendContext(c, visitor, term)
+	return v.extendContext(c, term)
 }

--- a/visitors/visitor.go
+++ b/visitors/visitor.go
@@ -84,6 +84,9 @@ type VisitorManager interface {
 	// children.
 	EnterNode(c Context, visitor interface{}, node interface{}) Cont
 
+	// Visits a node's children with the given context.
+	VisitChildren(c Context, vm VisitorManager, node interface{}) Cont
+
 	// Provides functionality for leaving a node, after visiting the node's
 	// children.
 	//
@@ -99,6 +102,7 @@ func NewVisitorManager(
 	c Context,
 	v interface{},
 	enter func(c Context, visitor interface{}, term interface{}) Cont,
+	visitChildren func(c Context, vm VisitorManager, term interface{}) Cont,
 	leave func(c Context, visitor interface{}, term interface{}, cont Cont) Cont,
 	extendContext func(c Context, visitor interface{}, term interface{}) Context,
 ) VisitorManager {
@@ -106,6 +110,7 @@ func NewVisitorManager(
 		context:       c,
 		visitor:       v,
 		enter:         enter,
+		visitChildren: visitChildren,
 		leave:         leave,
 		extendContext: extendContext,
 	}
@@ -128,6 +133,7 @@ type visitor struct {
 	context       Context
 	visitor       interface{}
 	enter         func(c Context, visitor interface{}, term interface{}) Cont
+	visitChildren func(c Context, vm VisitorManager, term interface{}) Cont
 	leave         func(c Context, visitor interface{}, term interface{}, cont Cont) Cont
 	extendContext func(c Context, visitor interface{}, term interface{}) Context
 }
@@ -142,6 +148,10 @@ func (v *visitor) Visitor() interface{} {
 
 func (v *visitor) EnterNode(c Context, visitor interface{}, term interface{}) Cont {
 	return v.enter(c, visitor, term)
+}
+
+func (v *visitor) VisitChildren(c Context, vm VisitorManager, term interface{}) Cont {
+	return v.visitChildren(c, vm, term)
 }
 
 func (v *visitor) LeaveNode(c Context, visitor interface{}, term interface{}, cont Cont) Cont {

--- a/visitors/visitor.go
+++ b/visitors/visitor.go
@@ -36,11 +36,32 @@ func NewContext() Context {
 	return new(context)
 }
 
+// An enum to indicate how a visitor's traversal should continue.
+type Cont int
+
+const (
+	// Indicates that the visitor should continue with normal traversal.
+	Continue Cont = iota
+
+	// Indicates that the visitor should end its traversal, but perform 'leave'
+	// operations as the traversal stack is unwound back to the root node.
+	Stop
+
+	// Indicates that the visitor should stop its traversal immediately. No
+	// 'leave' operations will be performed as the traversal stack is unwound
+	// back to the root node.
+	Abort
+
+	// Indicates that the visitor should not visit the children of the current
+	// node.
+	SkipChildren
+)
+
 // A visitor is made up of a context (which may extend the Context defined
 // above), an arbitrary visitor object, and an Apply function that takes the
 // context, the visitor object, and a term to visit.  It returns the context
-// passed in (possibly with modifications) as well as a boolean value
-// indicating whether to continue the traversal (false means stop).
+// passed in (possibly with modifications) as well as a value indicating how to
+// continue the traversal.
 //
 // Typically, the Apply method will use the context and the term to figure
 // out which method of the visitor object to call, and then call it with
@@ -48,7 +69,7 @@ func NewContext() Context {
 //
 // Factoring out the dispatch logic into Apply means the logic for figuring
 // out which visitor method to call is implemented once for a given data
-// structure, and custom visitors for that data structure can simply overload
+// structure, and custom visitors for that data structure can simply override
 // the methods on the vistor object they care about.  See
 // http_rest_spec_visitor for an example.
 //
@@ -58,20 +79,34 @@ func NewContext() Context {
 type VisitorManager interface {
 	Context() Context
 	Visitor() interface{}
-	Apply(c Context, visitor interface{}, term interface{}) bool
+
+	// Provides functionality for entering a node, before visiting the node's
+	// children.
+	EnterNode(c Context, visitor interface{}, node interface{}) Cont
+
+	// Provides functionality for leaving a node, after visiting the node's
+	// children.
+	//
+	// The given cont can be Continue, Stop, or SkipChildren, indicating the
+	// state of the traversal before leaving the node. Most implementations will
+	// want to return this value unchanged: for convenience, if SkipChildren is
+	// returned, the visitor framework will interpret this as Continue.
+	LeaveNode(c Context, visitor interface{}, node interface{}, cont Cont) Cont
 	ExtendContext(c Context, visitor interface{}, term interface{}) Context
 }
 
 func NewVisitorManager(
 	c Context,
 	v interface{},
-	apply func(c Context, visitor interface{}, term interface{}) bool,
+	enter func(c Context, visitor interface{}, term interface{}) Cont,
+	leave func(c Context, visitor interface{}, term interface{}, cont Cont) Cont,
 	extendContext func(c Context, visitor interface{}, term interface{}) Context,
 ) VisitorManager {
 	rv := visitor{
 		context:       c,
 		visitor:       v,
-		apply:         apply,
+		enter:         enter,
+		leave:         leave,
 		extendContext: extendContext,
 	}
 	return &rv
@@ -92,7 +127,8 @@ func (c *context) GetPath() []string {
 type visitor struct {
 	context       Context
 	visitor       interface{}
-	apply         func(c Context, visitor interface{}, term interface{}) bool
+	enter         func(c Context, visitor interface{}, term interface{}) Cont
+	leave         func(c Context, visitor interface{}, term interface{}, cont Cont) Cont
 	extendContext func(c Context, visitor interface{}, term interface{}) Context
 }
 
@@ -104,8 +140,12 @@ func (v *visitor) Visitor() interface{} {
 	return v.visitor
 }
 
-func (v *visitor) Apply(c Context, visitor interface{}, term interface{}) bool {
-	return v.apply(c, visitor, term)
+func (v *visitor) EnterNode(c Context, visitor interface{}, term interface{}) Cont {
+	return v.enter(c, visitor, term)
+}
+
+func (v *visitor) LeaveNode(c Context, visitor interface{}, term interface{}, cont Cont) Cont {
+	return v.leave(c, visitor, term, cont)
 }
 
 func (v *visitor) ExtendContext(c Context, visitor interface{}, term interface{}) Context {


### PR DESCRIPTION
This extends the visitor framework to provide more control over the traversal, and to add hooks for visiting metadata nodes. It also introduces a visitor for traversing a pair of nodes in tandem.

Pre- and post-order traversal has been generalized: the framework now exposes `enter` and `leave` methods for each node type. Preorder traversal can be obtained by implementing `enter` methods, whereas postorder traversal is obtained by implementing `leave` methods. The visiting of each node type's children can also be customized.

Visit methods now return an enum value rather than a `bool` to indicate how traversal should proceed. Possibilities are `Continue` to continue with normal traversal; `SkipChildren` allows the `enter` method to specify that the children of the current node should not be visited; `Stop` to stop the traversal, but execute the `leave` methods on the way back up to the root; and `Abort` halts the traversal immediately.

Added `enter`, `leave`, and `visitChildren` methods for metadata IR nodes.