### PR TITLE
Fixes & improvements to visitors

### DIFF
--- a/visitors/http_rest/http_rest_spec_visitor.go
+++ b/visitors/http_rest/http_rest_spec_visitor.go
@@ -446,11 +446,13 @@ func extendContext(cin Context, node interface{}) Context {
 			default:
 				ctx.setIsArg(false)
 				ctx = ctx.AppendRestPath("Response")
-				if rc == -1 {
-					ctx = ctx.AppendRestPath("default")
-				} else {
-					ctx = ctx.AppendRestPath(strconv.Itoa(int(rc)))
+
+				responseCode := "default"
+				if rc != -1 {
+					responseCode = strconv.Itoa(int(rc))
 				}
+				ctx = ctx.AppendRestPath(responseCode)
+				ctx.setResponseCode(responseCode)
 			}
 
 			var valueKey string
@@ -469,10 +471,18 @@ func extendContext(cin Context, node interface{}) Context {
 			} else if x := meta.GetBody(); x != nil {
 				ctx.setValueType(BODY)
 				valueKey = x.GetContentType().String()
+			} else if x := meta.GetAuth(); x != nil {
+				ctx.setValueType(AUTH)
+				ctx.setHttpAuthType(x.GetType())
+				valueKey = "Authorization"
 			}
 
 			ctx = ctx.AppendRestPath(ctx.GetValueType().String())
 			ctx = ctx.AppendRestPath(valueKey)
+
+			if node.GetOptional() != nil {
+				ctx.setIsOptional()
+			}
 
 			// Do nothing for HTTPEmpty
 		} else {

--- a/visitors/http_rest/normalize_arg_names.go
+++ b/visitors/http_rest/normalize_arg_names.go
@@ -1,0 +1,256 @@
+package http_rest
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
+	. "github.com/akitasoftware/akita-libs/visitors"
+	"github.com/akitasoftware/akita-libs/visitors/go_ast"
+	"github.com/pkg/errors"
+)
+
+// Represents the "name" of an argument to a method.
+type argName interface {
+	String() string
+
+	isArgName()
+}
+
+// Returns a version of the given method-argument map, wherein arguments are
+// indexed by name, rather than by hash.
+//
+// In IR method objects, arguments to requests and responses are indexed by
+// the arguments' hashes. However, because arguments are not normalized,
+// equivalent arguments can have different hashes, so these indices are not
+// useful for determining whether and how a method has changed.
+func getNormalizedArgMap(args map[string]*pb.Data) map[argName]*pb.Data {
+	// XXX Ignoring errors from the normalizer regarding non-HTTP metadata.
+	normalizer := newArgMapNormalizer()
+	Apply(normalizer, args)
+	return normalizer.normalizedMap
+}
+
+type argMapNormalizer struct {
+	DefaultSpecVisitorImpl
+
+	// Metadata for the method whose arg map is being normalized.
+	methodMeta *pb.HTTPMethodMeta
+
+	// The arg item whose name is being normalized.
+	arg *pb.Data
+
+	// The output of the normalization.
+	normalizedMap map[argName]*pb.Data
+
+	// Contains any arguments encountered with non-HTTP metadata.
+	nonHTTPArgs []*pb.Data
+
+	err error
+}
+
+var _ DefaultSpecVisitor = (*argMapNormalizer)(nil)
+
+func newArgMapNormalizer() *argMapNormalizer {
+	return &argMapNormalizer{
+		normalizedMap: make(map[argName]*pb.Data),
+	}
+}
+
+func (v *argMapNormalizer) EnterData(self interface{}, _ SpecVisitorContext, arg *pb.Data) Cont {
+	// Set our context.
+	v.arg = arg
+
+	// Make sure we have HTTP metadata for the current argument.
+	argMeta := arg.GetMeta().GetHttp()
+	if argMeta == nil {
+		v.nonHTTPArgs = append(v.nonHTTPArgs, arg)
+		return SkipChildren
+	}
+
+	return Continue
+}
+
+func (*argMapNormalizer) VisitDataChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, arg *pb.Data) Cont {
+	// Only visit the argument's metadata.
+	ctx := c.AppendPath("Meta")
+	return go_ast.ApplyWithContext(vm, ctx, arg.GetMeta())
+}
+
+func (v *argMapNormalizer) setName(name argName) {
+	if _, ok := v.normalizedMap[name]; ok {
+		panic(fmt.Sprintf("Unexpected duplicated name for %v", name))
+	}
+	v.normalizedMap[name] = v.arg
+}
+
+func (v *argMapNormalizer) LeaveData(self interface{}, _ SpecVisitorContext, _ *pb.Data, cont Cont) Cont {
+	v.arg = nil
+	return cont
+}
+
+// == Path parameters =========================================================
+
+type pathName struct {
+	index int
+}
+
+var _ argName = (*pathName)(nil)
+
+func (pathName) isArgName() {}
+
+func (v *argMapNormalizer) EnterHTTPPath(self interface{}, _ SpecVisitorContext, path *pb.HTTPPath) Cont {
+	template := v.methodMeta.GetPathTemplate()
+	components := strings.Split(template, "/")
+	for idx, component := range components {
+		if component == path.GetKey() {
+			v.setName(pathName{
+				index: idx,
+			})
+			return SkipChildren
+		}
+	}
+
+	v.err = errors.Errorf("Path parameter %q not found in %q", path.GetKey(), template)
+	return SkipChildren
+}
+
+func (n pathName) String() string {
+	return strconv.Itoa(n.index)
+}
+
+// == Query parameters ========================================================
+
+type queryName struct {
+	name string
+}
+
+var _ argName = (*queryName)(nil)
+
+func (queryName) isArgName() {}
+
+func (v *argMapNormalizer) EnterHTTPQuery(self interface{}, _ SpecVisitorContext, query *pb.HTTPQuery) Cont {
+	v.setName(queryName{
+		name: query.GetKey(),
+	})
+	return SkipChildren
+}
+
+func (n queryName) String() string {
+	return n.name
+}
+
+// == Header parameters =======================================================
+
+type headerName struct {
+	name string
+}
+
+var _ argName = (*headerName)(nil)
+
+func (headerName) isArgName() {}
+
+func (v *argMapNormalizer) EnterHTTPHeader(self interface{}, _ SpecVisitorContext, header *pb.HTTPHeader) Cont {
+	v.setName(headerName{
+		name: header.GetKey(),
+	})
+	return SkipChildren
+}
+
+func (n headerName) String() string {
+	return n.name
+}
+
+// == Cookie parameters =======================================================
+
+type cookieName struct {
+	name string
+}
+
+var _ argName = (*cookieName)(nil)
+
+func (cookieName) isArgName() {}
+
+func (v *argMapNormalizer) EnterHTTPCookie(self interface{}, _ SpecVisitorContext, cookie *pb.HTTPCookie) Cont {
+	v.setName(cookieName{
+		name: cookie.GetKey(),
+	})
+	return SkipChildren
+}
+
+func (n cookieName) String() string {
+	return n.name
+}
+
+// == Body parameters =========================================================
+
+type bodyName struct{}
+
+var _ argName = (*bodyName)(nil)
+
+func (bodyName) isArgName() {}
+
+func (v *argMapNormalizer) EnterHTTPBody(self interface{}, _ SpecVisitorContext, body *pb.HTTPBody) Cont {
+	// Assumes there is at most one per method.
+	v.setName(bodyName{})
+	return SkipChildren
+}
+
+func (n bodyName) String() string {
+	return "(body)"
+}
+
+// == Empty parameters ========================================================
+
+type emptyName struct{}
+
+var _ argName = (*bodyName)(nil)
+
+func (emptyName) isArgName() {}
+
+func (v *argMapNormalizer) EnterHTTPEmpty(self interface{}, _ SpecVisitorContext, empty *pb.HTTPEmpty) Cont {
+	// Assumes there is at most one per method.
+	v.setName(emptyName{})
+	return SkipChildren
+}
+
+func (n emptyName) String() string {
+	return ""
+}
+
+// == Auth parameters =========================================================
+
+type authName struct{}
+
+var _ argName = (*authName)(nil)
+
+func (authName) isArgName() {}
+
+func (v *argMapNormalizer) EnterAuth(_ SpecVisitorContext, auth *pb.HTTPAuth) Cont {
+	// Assumes there is at most one per method.
+	v.setName(authName{})
+	return SkipChildren
+}
+
+func (n authName) String() string {
+	return "Authorization"
+}
+
+// == Multipart body parameters ===============================================
+
+type multipartName struct{}
+
+var _ argName = (*multipartName)(nil)
+
+func (multipartName) isArgName() {}
+
+func (v *argMapNormalizer) EnterMultipart(_ SpecVisitorContext, multipart *pb.HTTPMultipart) Cont {
+	// Assumes there is at most one per method.
+	v.setName(multipartName{})
+	return SkipChildren
+}
+
+func (n multipartName) String() string {
+	return "(multipart)"
+}

--- a/visitors/http_rest/spec_pair_visitor_context.go
+++ b/visitors/http_rest/spec_pair_visitor_context.go
@@ -12,6 +12,7 @@ type SpecPairVisitorContext interface {
 
 	GetLeftContext() SpecVisitorContext
 	GetRightContext() SpecVisitorContext
+	SplitContext() (SpecVisitorContext, SpecVisitorContext)
 
 	AppendRestPaths(string, string) SpecPairVisitorContext
 	GetRestPaths() ([]string, []string)
@@ -55,6 +56,10 @@ func (c *specPairVisitorContext) GetLeftContext() SpecVisitorContext {
 
 func (c *specPairVisitorContext) GetRightContext() SpecVisitorContext {
 	return c.right
+}
+
+func (c *specPairVisitorContext) SplitContext() (SpecVisitorContext, SpecVisitorContext) {
+	return c.left, c.right
 }
 
 func (c *specPairVisitorContext) AppendPaths(left, right string) visitors.PairContext {

--- a/visitors/http_rest_diff/spec_diff_visitor.go
+++ b/visitors/http_rest_diff/spec_diff_visitor.go
@@ -23,11 +23,6 @@ import (
 type SpecDiffVisitor interface {
 	http_rest.SpecPairVisitor
 
-	EnterAddedOrRemovedHTTPAuth(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth) Cont
-	EnterChangedHTTPAuth(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth) Cont
-	LeaveAddedOrRemovedHTTPAuth(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth, cont Cont) Cont
-	LeaveChangedHTTPAuth(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth, cont Cont) Cont
-
 	EnterAddedOrRemovedData(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.Data) Cont
 	LeaveAddedOrRemovedData(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.Data, cont Cont) Cont
 
@@ -110,68 +105,6 @@ func (*DefaultSpecDiffVisitorImpl) LeaveAddedOrRemovedNode(self interface{}, ctx
 func (*DefaultSpecDiffVisitorImpl) LeaveChangedNode(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right interface{}, cont Cont) Cont {
 	v := self.(DefaultSpecDiffVisitor)
 	return v.LeaveDiff(self, ctx, left, right, cont)
-}
-
-// == HTTPAuth ================================================================
-
-func (*DefaultSpecDiffVisitorImpl) EnterHTTPAuths(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth) Cont {
-	v := self.(SpecDiffVisitor)
-
-	if left == nil && right == nil {
-		return SkipChildren
-	}
-
-	if left == nil || right == nil {
-		return v.EnterAddedOrRemovedHTTPAuth(self, ctx, left, right)
-	}
-
-	if left.Type != right.Type {
-		return v.EnterChangedHTTPAuth(self, ctx, left, right)
-	}
-
-	return Continue
-}
-
-func (*DefaultSpecDiffVisitorImpl) LeaveHTTPAuths(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth, cont Cont) Cont {
-	v := self.(SpecDiffVisitor)
-
-	if left == nil && right == nil {
-		return cont
-	}
-
-	if left == nil || right == nil {
-		return v.LeaveAddedOrRemovedHTTPAuth(self, ctx, left, right, cont)
-	}
-
-	if left.Type != right.Type {
-		return v.LeaveChangedHTTPAuth(self, ctx, left, right, cont)
-	}
-
-	return cont
-}
-
-// Delegates to EnterAddedOrRemovedNode.
-func (*DefaultSpecDiffVisitorImpl) EnterAddedOrRemovedHTTPAuth(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth) Cont {
-	v := self.(DefaultSpecDiffVisitor)
-	return v.EnterAddedOrRemovedNode(self, ctx, left, right)
-}
-
-// Delegates to EnterChangedNode.
-func (*DefaultSpecDiffVisitorImpl) EnterChangedHTTPAuth(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth) Cont {
-	v := self.(DefaultSpecDiffVisitor)
-	return v.EnterChangedNode(self, ctx, left, right)
-}
-
-// Delegates to LeaveAddedOrRemovedNode.
-func (*DefaultSpecDiffVisitorImpl) LeaveAddedOrRemovedHTTPAuth(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth, cont Cont) Cont {
-	v := self.(DefaultSpecDiffVisitor)
-	return v.LeaveAddedOrRemovedNode(self, ctx, left, right, cont)
-}
-
-// Delegates to LeaveChangedNode.
-func (*DefaultSpecDiffVisitorImpl) LeaveChangedHTTPAuth(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.HTTPAuth, cont Cont) Cont {
-	v := self.(DefaultSpecDiffVisitor)
-	return v.LeaveChangedNode(self, ctx, left, right, cont)
 }
 
 // == Data ====================================================================


### PR DESCRIPTION
Pair visitors should now visit corresponding method parameters correctly. We were previously using map keys to pair up parameters. We now use normalized names to do the pairing.

Augmented visitor contexts with more information to ease diff computation. Specifically, an `AUTH` value type was added, and we now track the following.

  * The type (basic or bearer) of any authentication header being visited.
  * Whether an optional field is being visited.
  * The response code of any response being visited.

Fixed `SpecDiffVisitor` to correct a misunderstanding of how authentication headers are represented in the IR. We no longer have visitor methods for entering and leaving added/removed/changed `HTTPAuth` nodes, since authentication headers are represented as `Data`.