### PR TITLE
Richer context representation & bug fixes

### DIFF
--- a/visitors/go_ast/ast_visitor_test.go
+++ b/visitors/go_ast/ast_visitor_test.go
@@ -29,9 +29,7 @@ func countIntLeave(c Context, v interface{}, x interface{}, cont Cont) Cont {
 	return cont
 }
 
-func extendContext(c Context, x interface{}) Context {
-	return c
-}
+func extendContext(c Context, x interface{}) {}
 
 func TestApply(t *testing.T) {
 	counter := new(Counter)

--- a/visitors/go_ast_pair/ast_pair_visitor_test.go
+++ b/visitors/go_ast_pair/ast_pair_visitor_test.go
@@ -33,9 +33,7 @@ func countIntLeave(c PairContext, v interface{}, left, right interface{}, cont C
 	return cont
 }
 
-func extendContext(c PairContext, left, right interface{}) PairContext {
-	return c
-}
+func extendContext(c PairContext, left, right interface{}) {}
 
 func TestApply(t *testing.T) {
 	counter := new(Counter)

--- a/visitors/http_rest/http_rest_spec_visitor_context.go
+++ b/visitors/http_rest/http_rest_spec_visitor_context.go
@@ -25,10 +25,6 @@ func (t HttpValueType) String() string {
 type SpecVisitorContext interface {
 	visitors.Context
 
-	// Used by the visitor infrastructure to construct a REST path by replacing
-	// parts of the AST path with names from DataMeta.
-	AppendRestPath(string) SpecVisitorContext
-
 	// Gets the REST path, which is similar to the AST path but using names
 	// from DataMeta and MethodMeta objects where appropriate, as well as
 	// hiding names of container data structures.
@@ -81,6 +77,13 @@ type SpecVisitorContext interface {
 	// Returns the host.
 	GetHost() string
 
+	// Returns the innermost Data instance being visited and its context.
+	GetInnermostData() (*pb.Data, SpecVisitorContext)
+
+	// Used by the visitor infrastructure to construct a REST path by replacing
+	// parts of the AST path with names from DataMeta.
+	appendRestPath(string)
+
 	setIsArg(bool)
 	setIsOptional()
 	setValueType(HttpValueType)
@@ -89,8 +92,10 @@ type SpecVisitorContext interface {
 	setResponseCode(string)
 }
 
-type httpRestSpecVisitorContext struct {
-	path     []string
+type specVisitorContext struct {
+	path  visitors.ContextPath
+	outer SpecVisitorContext
+
 	restPath []string
 
 	// nil means we're not sure if this is an arg or response value.
@@ -110,98 +115,133 @@ type httpRestSpecVisitorContext struct {
 	restOperation string
 }
 
-var _ SpecVisitorContext = (*httpRestSpecVisitorContext)(nil)
+var _ SpecVisitorContext = (*specVisitorContext)(nil)
 
-func (c *httpRestSpecVisitorContext) AppendPath(s string) visitors.Context {
-	rv := *c
-	rv.path = append(c.GetPath(), s)
-	return &rv
+func (c *specVisitorContext) EnterStruct(structNode interface{}, fieldName string) visitors.Context {
+	return c.appendPath(visitors.ContextPathElement{
+		AncestorNode: structNode,
+		OutEdge:      visitors.NewStructFieldEdge(fieldName),
+	})
 }
 
-func (c *httpRestSpecVisitorContext) GetPath() []string {
+func (c *specVisitorContext) EnterArray(arrayNode interface{}, elementIndex int) visitors.Context {
+	return c.appendPath(visitors.ContextPathElement{
+		AncestorNode: arrayNode,
+		OutEdge:      visitors.NewArrayElementEdge(elementIndex),
+	})
+}
+
+func (c *specVisitorContext) EnterMapValue(mapNode, mapKey interface{}) visitors.Context {
+	return c.appendPath(visitors.ContextPathElement{
+		AncestorNode: mapNode,
+		OutEdge:      visitors.NewMapValueEdge(mapKey),
+	})
+}
+
+func (c *specVisitorContext) appendPath(e visitors.ContextPathElement) *specVisitorContext {
+	result := *c
+	result.path = append(result.path, e)
+	result.outer = c
+	return &result
+}
+
+func (c *specVisitorContext) GetPath() visitors.ContextPath {
 	return c.path
 }
 
-func (c *httpRestSpecVisitorContext) AppendRestPath(s string) SpecVisitorContext {
-	rv := *c
-	rv.restPath = append(c.GetRestPath(), s)
-	return &rv
+func (c *specVisitorContext) GetOuter() visitors.Context {
+	return c.outer
 }
 
-func (c *httpRestSpecVisitorContext) GetRestPath() []string {
+func (c *specVisitorContext) appendRestPath(s string) {
+	c.restPath = append(c.GetRestPath(), s)
+}
+
+func (c *specVisitorContext) GetRestPath() []string {
 	return c.restPath
 }
 
-func (c *httpRestSpecVisitorContext) GetRestOperation() string {
+func (c *specVisitorContext) GetRestOperation() string {
 	return c.restOperation
 }
 
-func (c *httpRestSpecVisitorContext) setRestOperation(op string) {
+func (c *specVisitorContext) setRestOperation(op string) {
 	c.restOperation = op
 }
 
-func (c *httpRestSpecVisitorContext) IsArg() bool {
+func (c *specVisitorContext) IsArg() bool {
 	if c.isArg != nil {
 		return *c.isArg
 	}
 	return false
 }
 
-func (c *httpRestSpecVisitorContext) IsResponse() bool {
+func (c *specVisitorContext) IsResponse() bool {
 	if c.isArg != nil {
 		return !*c.isArg
 	}
 	return false
 }
 
-func (c *httpRestSpecVisitorContext) IsOptional() bool {
+func (c *specVisitorContext) IsOptional() bool {
 	return c.isOptional
 }
 
-func (c *httpRestSpecVisitorContext) GetValueType() HttpValueType {
+func (c *specVisitorContext) GetValueType() HttpValueType {
 	return c.valueType
 }
 
-func (c *httpRestSpecVisitorContext) GetHttpAuthType() *pb.HTTPAuth_HTTPAuthType {
+func (c *specVisitorContext) GetHttpAuthType() *pb.HTTPAuth_HTTPAuthType {
 	return c.httpAuthType
 }
 
-func (c *httpRestSpecVisitorContext) GetArgPath() []string {
+func (c *specVisitorContext) GetArgPath() []string {
 	if !c.IsArg() {
 		return nil
 	}
 	return c.getTopLevelDataPath()
 }
 
-func (c *httpRestSpecVisitorContext) GetResponsePath() []string {
+func (c *specVisitorContext) GetResponsePath() []string {
 	if !c.IsResponse() {
 		return nil
 	}
 	return c.getTopLevelDataPath()
 }
 
-func (c *httpRestSpecVisitorContext) GetEndpointPath() string {
+func (c *specVisitorContext) GetEndpointPath() string {
 	if len(c.restPath) < 3 {
 		return ""
 	}
 	return c.restPath[2]
 }
 
-func (c *httpRestSpecVisitorContext) GetResponseCode() *string {
+func (c *specVisitorContext) GetResponseCode() *string {
 	if !c.IsResponse() {
 		return nil
 	}
 	return c.responseCode
 }
 
-func (c *httpRestSpecVisitorContext) GetHost() string {
+func (c *specVisitorContext) GetHost() string {
 	if len(c.restPath) < 1 {
 		return ""
 	}
 	return c.restPath[0]
 }
 
-func (c *httpRestSpecVisitorContext) getTopLevelDataPath() []string {
+func (c *specVisitorContext) GetInnermostData() (*pb.Data, SpecVisitorContext) {
+	for c != nil {
+		if data, ok := c.path.GetLast().AncestorNode.(*pb.Data); ok {
+			return data, c.outer
+		}
+		c = c.outer.(*specVisitorContext)
+	}
+
+	return nil, nil
+}
+
+func (c *specVisitorContext) getTopLevelDataPath() []string {
 	p := c.GetRestPath()
 	if len(p) > c.topDataIndex+1 {
 		return p[c.topDataIndex+1:]
@@ -209,26 +249,26 @@ func (c *httpRestSpecVisitorContext) getTopLevelDataPath() []string {
 	return nil
 }
 
-func (c *httpRestSpecVisitorContext) setIsArg(isArg bool) {
+func (c *specVisitorContext) setIsArg(isArg bool) {
 	c.isArg = &isArg
 }
 
-func (c *httpRestSpecVisitorContext) setIsOptional() {
+func (c *specVisitorContext) setIsOptional() {
 	c.isOptional = true
 }
 
-func (c *httpRestSpecVisitorContext) setValueType(vt HttpValueType) {
+func (c *specVisitorContext) setValueType(vt HttpValueType) {
 	c.valueType = vt
 }
 
-func (c *httpRestSpecVisitorContext) setResponseCode(code string) {
+func (c *specVisitorContext) setResponseCode(code string) {
 	c.responseCode = &code
 }
 
-func (c *httpRestSpecVisitorContext) setHttpAuthType(at pb.HTTPAuth_HTTPAuthType) {
+func (c *specVisitorContext) setHttpAuthType(at pb.HTTPAuth_HTTPAuthType) {
 	c.httpAuthType = &at
 }
 
-func (c *httpRestSpecVisitorContext) setTopLevelDataIndex(i int) {
+func (c *specVisitorContext) setTopLevelDataIndex(i int) {
 	c.topDataIndex = i
 }

--- a/visitors/http_rest/normalize_arg_names.go
+++ b/visitors/http_rest/normalize_arg_names.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Represents the "name" of an argument to a method.
-type argName interface {
+type ArgName interface {
 	String() string
 
 	isArgName()
@@ -25,7 +25,7 @@ type argName interface {
 // the arguments' hashes. However, because arguments are not normalized,
 // equivalent arguments can have different hashes, so these indices are not
 // useful for determining whether and how a method has changed.
-func getNormalizedArgNames(args map[string]*pb.Data) map[argName]string {
+func GetNormalizedArgNames(args map[string]*pb.Data) map[ArgName]string {
 	// XXX Ignoring errors from the normalizer regarding non-HTTP metadata.
 	normalizer := newArgNameNormalizer()
 	Apply(normalizer, args)
@@ -42,7 +42,7 @@ type argNameNormalizer struct {
 	nonNormalizedArgName string
 
 	// The output of the normalization.
-	normalizationMap map[argName]string
+	normalizationMap map[ArgName]string
 
 	// Contains any arguments encountered with non-HTTP metadata.
 	nonHTTPArgs []*pb.Data
@@ -54,7 +54,7 @@ var _ DefaultSpecVisitor = (*argNameNormalizer)(nil)
 
 func newArgNameNormalizer() *argNameNormalizer {
 	return &argNameNormalizer{
-		normalizationMap: make(map[argName]string),
+		normalizationMap: make(map[ArgName]string),
 	}
 }
 
@@ -77,7 +77,7 @@ func (*argNameNormalizer) VisitDataChildren(self interface{}, c SpecVisitorConte
 	return go_ast.ApplyWithContext(vm, c.EnterStruct(arg, "Meta"), arg.GetMeta)
 }
 
-func (v *argNameNormalizer) setName(name argName) {
+func (v *argNameNormalizer) setName(name ArgName) {
 	if _, ok := v.normalizationMap[name]; ok {
 		panic(fmt.Sprintf("Unexpected duplicated name for %v", name))
 	}
@@ -95,7 +95,7 @@ type pathName struct {
 	index int
 }
 
-var _ argName = (*pathName)(nil)
+var _ ArgName = (*pathName)(nil)
 
 func (pathName) isArgName() {}
 
@@ -125,7 +125,7 @@ type queryName struct {
 	name string
 }
 
-var _ argName = (*queryName)(nil)
+var _ ArgName = (*queryName)(nil)
 
 func (queryName) isArgName() {}
 
@@ -146,7 +146,7 @@ type headerName struct {
 	name string
 }
 
-var _ argName = (*headerName)(nil)
+var _ ArgName = (*headerName)(nil)
 
 func (headerName) isArgName() {}
 
@@ -167,7 +167,7 @@ type cookieName struct {
 	name string
 }
 
-var _ argName = (*cookieName)(nil)
+var _ ArgName = (*cookieName)(nil)
 
 func (cookieName) isArgName() {}
 
@@ -186,7 +186,7 @@ func (n cookieName) String() string {
 
 type bodyName struct{}
 
-var _ argName = (*bodyName)(nil)
+var _ ArgName = (*bodyName)(nil)
 
 func (bodyName) isArgName() {}
 
@@ -204,7 +204,7 @@ func (n bodyName) String() string {
 
 type emptyName struct{}
 
-var _ argName = (*bodyName)(nil)
+var _ ArgName = (*bodyName)(nil)
 
 func (emptyName) isArgName() {}
 
@@ -222,7 +222,7 @@ func (n emptyName) String() string {
 
 type authName struct{}
 
-var _ argName = (*authName)(nil)
+var _ ArgName = (*authName)(nil)
 
 func (authName) isArgName() {}
 
@@ -240,7 +240,7 @@ func (n authName) String() string {
 
 type multipartName struct{}
 
-var _ argName = (*multipartName)(nil)
+var _ ArgName = (*multipartName)(nil)
 
 func (multipartName) isArgName() {}
 

--- a/visitors/http_rest/normalize_arg_names.go
+++ b/visitors/http_rest/normalize_arg_names.go
@@ -74,7 +74,7 @@ func (v *argNameNormalizer) EnterData(self interface{}, ctx SpecVisitorContext, 
 
 func (*argNameNormalizer) VisitDataChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, arg *pb.Data) Cont {
 	// Only visit the argument's metadata.
-	return go_ast.ApplyWithContext(vm, c.EnterStruct(arg, "Meta"), arg.GetMeta)
+	return go_ast.ApplyWithContext(vm, c.EnterStruct(arg, "Meta"), arg.GetMeta())
 }
 
 func (v *argNameNormalizer) setName(name ArgName) {

--- a/visitors/http_rest/normalize_arg_names.go
+++ b/visitors/http_rest/normalize_arg_names.go
@@ -18,31 +18,31 @@ type argName interface {
 	isArgName()
 }
 
-// Returns a version of the given method-argument map, wherein arguments are
-// indexed by name, rather than by hash.
+// Returns a normalization map for the keys in the given method-argument map.
+// The return value maps normalized keys to keys in the given map.
 //
 // In IR method objects, arguments to requests and responses are indexed by
 // the arguments' hashes. However, because arguments are not normalized,
 // equivalent arguments can have different hashes, so these indices are not
 // useful for determining whether and how a method has changed.
-func getNormalizedArgMap(args map[string]*pb.Data) map[argName]*pb.Data {
+func getNormalizedArgNames(args map[string]*pb.Data) map[argName]string {
 	// XXX Ignoring errors from the normalizer regarding non-HTTP metadata.
-	normalizer := newArgMapNormalizer()
+	normalizer := newArgNameNormalizer()
 	Apply(normalizer, args)
-	return normalizer.normalizedMap
+	return normalizer.normalizationMap
 }
 
-type argMapNormalizer struct {
+type argNameNormalizer struct {
 	DefaultSpecVisitorImpl
 
-	// Metadata for the method whose arg map is being normalized.
+	// Metadata for the method whose argument names are being normalized.
 	methodMeta *pb.HTTPMethodMeta
 
-	// The arg item whose name is being normalized.
-	arg *pb.Data
+	// The arg name being normalized.
+	nonNormalizedArgName string
 
 	// The output of the normalization.
-	normalizedMap map[argName]*pb.Data
+	normalizationMap map[argName]string
 
 	// Contains any arguments encountered with non-HTTP metadata.
 	nonHTTPArgs []*pb.Data
@@ -50,17 +50,17 @@ type argMapNormalizer struct {
 	err error
 }
 
-var _ DefaultSpecVisitor = (*argMapNormalizer)(nil)
+var _ DefaultSpecVisitor = (*argNameNormalizer)(nil)
 
-func newArgMapNormalizer() *argMapNormalizer {
-	return &argMapNormalizer{
-		normalizedMap: make(map[argName]*pb.Data),
+func newArgNameNormalizer() *argNameNormalizer {
+	return &argNameNormalizer{
+		normalizationMap: make(map[argName]string),
 	}
 }
 
-func (v *argMapNormalizer) EnterData(self interface{}, _ SpecVisitorContext, arg *pb.Data) Cont {
+func (v *argNameNormalizer) EnterData(self interface{}, ctx SpecVisitorContext, arg *pb.Data) Cont {
 	// Set our context.
-	v.arg = arg
+	v.nonNormalizedArgName = ctx.GetPath().GetLast().OutEdge.String()
 
 	// Make sure we have HTTP metadata for the current argument.
 	argMeta := arg.GetMeta().GetHttp()
@@ -72,21 +72,20 @@ func (v *argMapNormalizer) EnterData(self interface{}, _ SpecVisitorContext, arg
 	return Continue
 }
 
-func (*argMapNormalizer) VisitDataChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, arg *pb.Data) Cont {
+func (*argNameNormalizer) VisitDataChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, arg *pb.Data) Cont {
 	// Only visit the argument's metadata.
-	ctx := c.AppendPath("Meta")
-	return go_ast.ApplyWithContext(vm, ctx, arg.GetMeta())
+	return go_ast.ApplyWithContext(vm, c.EnterStruct(arg, "Meta"), arg.GetMeta)
 }
 
-func (v *argMapNormalizer) setName(name argName) {
-	if _, ok := v.normalizedMap[name]; ok {
+func (v *argNameNormalizer) setName(name argName) {
+	if _, ok := v.normalizationMap[name]; ok {
 		panic(fmt.Sprintf("Unexpected duplicated name for %v", name))
 	}
-	v.normalizedMap[name] = v.arg
+	v.normalizationMap[name] = v.nonNormalizedArgName
 }
 
-func (v *argMapNormalizer) LeaveData(self interface{}, _ SpecVisitorContext, _ *pb.Data, cont Cont) Cont {
-	v.arg = nil
+func (v *argNameNormalizer) LeaveData(self interface{}, _ SpecVisitorContext, _ *pb.Data, cont Cont) Cont {
+	v.nonNormalizedArgName = ""
 	return cont
 }
 
@@ -100,7 +99,7 @@ var _ argName = (*pathName)(nil)
 
 func (pathName) isArgName() {}
 
-func (v *argMapNormalizer) EnterHTTPPath(self interface{}, _ SpecVisitorContext, path *pb.HTTPPath) Cont {
+func (v *argNameNormalizer) EnterHTTPPath(self interface{}, _ SpecVisitorContext, path *pb.HTTPPath) Cont {
 	template := v.methodMeta.GetPathTemplate()
 	components := strings.Split(template, "/")
 	for idx, component := range components {
@@ -130,7 +129,7 @@ var _ argName = (*queryName)(nil)
 
 func (queryName) isArgName() {}
 
-func (v *argMapNormalizer) EnterHTTPQuery(self interface{}, _ SpecVisitorContext, query *pb.HTTPQuery) Cont {
+func (v *argNameNormalizer) EnterHTTPQuery(self interface{}, _ SpecVisitorContext, query *pb.HTTPQuery) Cont {
 	v.setName(queryName{
 		name: query.GetKey(),
 	})
@@ -151,7 +150,7 @@ var _ argName = (*headerName)(nil)
 
 func (headerName) isArgName() {}
 
-func (v *argMapNormalizer) EnterHTTPHeader(self interface{}, _ SpecVisitorContext, header *pb.HTTPHeader) Cont {
+func (v *argNameNormalizer) EnterHTTPHeader(self interface{}, _ SpecVisitorContext, header *pb.HTTPHeader) Cont {
 	v.setName(headerName{
 		name: header.GetKey(),
 	})
@@ -172,7 +171,7 @@ var _ argName = (*cookieName)(nil)
 
 func (cookieName) isArgName() {}
 
-func (v *argMapNormalizer) EnterHTTPCookie(self interface{}, _ SpecVisitorContext, cookie *pb.HTTPCookie) Cont {
+func (v *argNameNormalizer) EnterHTTPCookie(self interface{}, _ SpecVisitorContext, cookie *pb.HTTPCookie) Cont {
 	v.setName(cookieName{
 		name: cookie.GetKey(),
 	})
@@ -191,7 +190,7 @@ var _ argName = (*bodyName)(nil)
 
 func (bodyName) isArgName() {}
 
-func (v *argMapNormalizer) EnterHTTPBody(self interface{}, _ SpecVisitorContext, body *pb.HTTPBody) Cont {
+func (v *argNameNormalizer) EnterHTTPBody(self interface{}, _ SpecVisitorContext, body *pb.HTTPBody) Cont {
 	// Assumes there is at most one per method.
 	v.setName(bodyName{})
 	return SkipChildren
@@ -209,7 +208,7 @@ var _ argName = (*bodyName)(nil)
 
 func (emptyName) isArgName() {}
 
-func (v *argMapNormalizer) EnterHTTPEmpty(self interface{}, _ SpecVisitorContext, empty *pb.HTTPEmpty) Cont {
+func (v *argNameNormalizer) EnterHTTPEmpty(self interface{}, _ SpecVisitorContext, empty *pb.HTTPEmpty) Cont {
 	// Assumes there is at most one per method.
 	v.setName(emptyName{})
 	return SkipChildren
@@ -227,7 +226,7 @@ var _ argName = (*authName)(nil)
 
 func (authName) isArgName() {}
 
-func (v *argMapNormalizer) EnterAuth(_ SpecVisitorContext, auth *pb.HTTPAuth) Cont {
+func (v *argNameNormalizer) EnterAuth(_ SpecVisitorContext, auth *pb.HTTPAuth) Cont {
 	// Assumes there is at most one per method.
 	v.setName(authName{})
 	return SkipChildren
@@ -245,7 +244,7 @@ var _ argName = (*multipartName)(nil)
 
 func (multipartName) isArgName() {}
 
-func (v *argMapNormalizer) EnterMultipart(_ SpecVisitorContext, multipart *pb.HTTPMultipart) Cont {
+func (v *argNameNormalizer) EnterMultipart(_ SpecVisitorContext, multipart *pb.HTTPMultipart) Cont {
 	// Assumes there is at most one per method.
 	v.setName(multipartName{})
 	return SkipChildren

--- a/visitors/http_rest/spec_pair_visitor.go
+++ b/visitors/http_rest/spec_pair_visitor.go
@@ -175,22 +175,22 @@ func (*DefaultSpecPairVisitorImpl) VisitMethodChildren(self interface{}, c SpecP
 		return Continue
 	}
 
-	keepGoing := go_ast_pair.ApplyWithContext(vm, c.AppendPaths("Id", "Id"), left.Id, right.Id)
+	keepGoing := go_ast_pair.ApplyWithContext(vm, c.EnterStructs(left, "Id", right, "Id"), left.Id, right.Id)
 	if result := handleKeepGoing(keepGoing); result != nil {
 		return *result
 	}
 
-	keepGoing = v.VisitMethodArgs(self, c.AppendPaths("Args", "Args"), vm, left.Args, right.Args)
+	keepGoing = v.VisitMethodArgs(self, c.EnterStructs(left, "Args", right, "Args"), vm, left.Args, right.Args)
 	if result := handleKeepGoing(keepGoing); result != nil {
 		return *result
 	}
 
-	keepGoing = v.VisitMethodArgs(self, c.AppendPaths("Responses", "Responses"), vm, left.Responses, right.Responses)
+	keepGoing = v.VisitMethodArgs(self, c.EnterStructs(left, "Responses", right, "Responses"), vm, left.Responses, right.Responses)
 	if result := handleKeepGoing(keepGoing); result != nil {
 		return *result
 	}
 
-	keepGoing = go_ast_pair.ApplyWithContext(vm, c.AppendPaths("Meta", "Meta"), left.Meta, right.Meta)
+	keepGoing = go_ast_pair.ApplyWithContext(vm, c.EnterStructs(left, "Meta", right, "Meta"), left.Meta, right.Meta)
 	if result := handleKeepGoing(keepGoing); result != nil {
 		return *result
 	}
@@ -219,17 +219,21 @@ func (*DefaultSpecPairVisitorImpl) VisitMethodArgs(self interface{}, ctxt PairCo
 	keepGoing := Continue
 
 	// Normalize arguments on both sides.
-	normalizedLeft := getNormalizedArgMap(leftArgs)
-	normalizedRight := getNormalizedArgMap(rightArgs)
+	normalizedLeft := getNormalizedArgNames(leftArgs)
+	normalizedRight := getNormalizedArgNames(rightArgs)
 
 	// Line up left arguments with the right and visit in pairs. Remove any
 	// matching arguments on the right.
-	for name, leftArg := range normalizedLeft {
-		if rightArg, ok := normalizedRight[name]; ok {
-			keepGoing = go_ast_pair.ApplyWithContext(vm, ctxt.AppendPaths(name.String(), name.String()), leftArg, rightArg)
+	for name, leftName := range normalizedLeft {
+		leftArg := leftArgs[leftName]
+		if rightName, ok := normalizedRight[name]; ok {
+			rightArg := rightArgs[rightName]
+			ctxt := ctxt.EnterMapValues(leftArgs, leftName, rightArgs, rightName)
+			keepGoing = go_ast_pair.ApplyWithContext(vm, ctxt, leftArg, rightArg)
 			delete(normalizedRight, name)
 		} else {
-			keepGoing = go_ast_pair.ApplyWithContext(vm, ctxt.AppendPaths(name.String(), name.String()), leftArg, nil)
+			ctxt := ctxt.EnterMapValues(leftArgs, leftName, rightArgs, nil)
+			keepGoing = go_ast_pair.ApplyWithContext(vm, ctxt, leftArg, go_ast_pair.ZeroOf(leftArg))
 		}
 
 		if result := handleKeepGoing(keepGoing); result != nil {
@@ -238,8 +242,10 @@ func (*DefaultSpecPairVisitorImpl) VisitMethodArgs(self interface{}, ctxt PairCo
 	}
 
 	// Any remaining arguments on the right don't have a match on the left.
-	for name, rightArg := range normalizedRight {
-		keepGoing = go_ast_pair.ApplyWithContext(vm, ctxt.AppendPaths(name.String(), name.String()), nil, rightArg)
+	for _, rightName := range normalizedRight {
+		rightArg := rightArgs[rightName]
+		ctxt := ctxt.EnterMapValues(leftArgs, nil, rightArgs, rightName)
+		keepGoing = go_ast_pair.ApplyWithContext(vm, ctxt, (go_ast_pair.ZeroOf(rightArg)), rightArg)
 
 		if result := handleKeepGoing(keepGoing); result != nil {
 			return *result
@@ -512,7 +518,7 @@ func (*DefaultSpecPairVisitorImpl) LeaveDifferentTypes(self interface{}, c SpecP
 }
 
 // extendContext implementation for SpecPairVisitor.
-func extendPairContext(cin PairContext, left, right interface{}) PairContext {
+func extendPairContext(cin PairContext, left, right interface{}) {
 	ctx, ok := cin.(SpecPairVisitorContext)
 	if !ok {
 		panic(fmt.Sprintf("http_rest.extendPairContext expected SpecPairVisitorContext, got %s",
@@ -521,13 +527,12 @@ func extendPairContext(cin PairContext, left, right interface{}) PairContext {
 
 	ctx.ExtendLeftContext(left)
 	ctx.ExtendRightContext(right)
-	return ctx
 }
 
 // enter implementation for SpecVisitor.
 func enterPair(cin PairContext, visitor interface{}, left, right interface{}) Cont {
 	v, _ := visitor.(SpecPairVisitor)
-	ctx, ok := extendPairContext(cin, left, right).(SpecPairVisitorContext)
+	ctx, ok := cin.(SpecPairVisitorContext)
 	if !ok {
 		panic(fmt.Sprintf("http_rest.enterPair expected SpecPairVisitorContext, got %s",
 			reflect.TypeOf(cin)))
@@ -730,7 +735,7 @@ func visitPairChildren(cin PairContext, vm PairVisitorManager, left, right inter
 // leave implementation for SpecPairVisitor.
 func leavePair(cin PairContext, visitor interface{}, left, right interface{}, cont Cont) Cont {
 	v, _ := visitor.(SpecPairVisitor)
-	ctx, ok := extendPairContext(cin, left, right).(SpecPairVisitorContext)
+	ctx, ok := cin.(SpecPairVisitorContext)
 	if !ok {
 		panic(fmt.Sprintf("http_rest.leave expected SpecPairVisitorContext, got %s",
 			reflect.TypeOf(cin)))

--- a/visitors/http_rest/spec_pair_visitor.go
+++ b/visitors/http_rest/spec_pair_visitor.go
@@ -219,8 +219,8 @@ func (*DefaultSpecPairVisitorImpl) VisitMethodArgs(self interface{}, ctxt PairCo
 	keepGoing := Continue
 
 	// Normalize arguments on both sides.
-	normalizedLeft := getNormalizedArgNames(leftArgs)
-	normalizedRight := getNormalizedArgNames(rightArgs)
+	normalizedLeft := GetNormalizedArgNames(leftArgs)
+	normalizedRight := GetNormalizedArgNames(rightArgs)
 
 	// Line up left arguments with the right and visit in pairs. Remove any
 	// matching arguments on the right.


### PR DESCRIPTION
Contexts now track the traversal path more richly. They have the set of nodes going back to the root, and a representation of the edge that was followed from each node.

Each context now has a pointer to its parent.

We can now obtain from the context the innermost `Data` node being visited, and that node's context.

Made `ExtendContext` completely imperative, rather than partially imperative and partially functional.

Just call `ExtendContext` once when visiting a node. Previously, we were calling it thrice: within `Enter`, before calling `VisitChildren`, and within `Leave`.

Fix: we weren't aborting traversal immediately if `VisitChildren` requested an abort.

Fix pair visitor: when visiting a node that only exists in one half of the pair, we were always calling `EnterDifferentTypes` and `LeaveDifferentTypes` because we were using a nil-typed `nil` for the missing value.

Gave `httpRestSpecVisitorContext` a shorter name.