### PR TITLE
Convert strings in traces to other types depending on context

### DIFF
--- a/spec_util/categorize.go
+++ b/spec_util/categorize.go
@@ -244,13 +244,18 @@ func CategorizeString(str string) PrimitiveValue {
 		return primValueImpl{v: v}
 	} else if v, err := strconv.ParseBool(str); err == nil {
 		return primValueImpl{v: v}
-	} else if !utf8.ValidString(str) {
-		// Protobuf string can only represent UTF-8 values, so we treat strings
-		// containing invalid UTF-8 runes as bytes.
-		// https://app.clubhouse.io/akita-software/story/1427
-		return primValueImpl{v: []byte(str)}
 	}
-	return primValueImpl{v: str}
+	return nonUtf8StringWorkaround(str)
+}
+
+// A workaround to handle non-UTF-8 strings. Protobuf string can only represent
+// UTF-8 values, so we treat strings containing invalid UTF-8 runes as bytes.
+// https://app.clubhouse.io/akita-software/story/1427
+func nonUtf8StringWorkaround(str string) PrimitiveValue {
+	if utf8.ValidString(str) {
+		return primValueImpl{v: str}
+	}
+	return primValueImpl{v: []byte(str)}
 }
 
 func ToPrimitiveValue(v interface{}) (PrimitiveValue, error) {
@@ -264,7 +269,7 @@ func ToPrimitiveValue(v interface{}) (PrimitiveValue, error) {
 	case reflect.Bool:
 		// Do nothing
 	case reflect.String:
-		return CategorizeString(v.(string)), nil
+		return nonUtf8StringWorkaround(v.(string)), nil
 	case reflect.Slice:
 		if bs, ok := v.([]byte); ok {
 			v = bs

--- a/spec_util/categorize.go
+++ b/spec_util/categorize.go
@@ -258,7 +258,18 @@ func nonUtf8StringWorkaround(str string) PrimitiveValue {
 	return primValueImpl{v: []byte(str)}
 }
 
-func ToPrimitiveValue(v interface{}) (PrimitiveValue, error) {
+type InterpretStrings bool
+
+const (
+	// Indicates that strings should be interpreted as numbers or boolean values
+	// wherever possible.
+	INTERPRET_STRINGS InterpretStrings = true
+
+	// Indicates that strings should remain strings.
+	NO_INTERPRET_STRINGS InterpretStrings = false
+)
+
+func ToPrimitiveValue(v interface{}, interpretStrings InterpretStrings) (PrimitiveValue, error) {
 	switch reflect.ValueOf(v).Kind() {
 	case reflect.Int:
 		v = int64(v.(int))
@@ -269,6 +280,9 @@ func ToPrimitiveValue(v interface{}) (PrimitiveValue, error) {
 	case reflect.Bool:
 		// Do nothing
 	case reflect.String:
+		if interpretStrings {
+			return CategorizeString(v.(string)), nil
+		}
 		return nonUtf8StringWorkaround(v.(string)), nil
 	case reflect.Slice:
 		if bs, ok := v.([]byte); ok {


### PR DESCRIPTION
When producing IR from traces, we don't always want to auto-convert strings to ints and bools. Doing this conversion in JSON data causes us to generate incorrect specs.