### PR TITLE
Fix for when visiting starts at non-argument Data node

### DIFF
--- a/visitors/go_ast_pair/ast_pair_visitor.go
+++ b/visitors/go_ast_pair/ast_pair_visitor.go
@@ -55,7 +55,7 @@ func (t *astPairVisitor) visit(c PairContext, left, right interface{}) Cont {
 			return Abort
 		case Continue:
 		case SkipChildren:
-			panic("VisitChildren shouldn't return SkipChildren")
+			panic(fmt.Sprintf("VisitChildren shouldn't return SkipChildren. Visitor %v, nodes (%v, %v)", reflect.TypeOf(t.vm.Visitor()), reflect.TypeOf(left), reflect.TypeOf(right)))
 		case Stop:
 		default:
 			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))

--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -509,23 +509,27 @@ func extendContext(cin Context, node interface{}) {
 
 			// Do nothing for HTTPEmpty
 		} else {
+			// No path to update if we're at the root of the AST subtree being
+			// visited.
 			astPath := ctx.GetPath()
-			astPathEdge := astPath.GetLast().OutEdge
+			if !astPath.IsEmpty() {
+				astPathEdge := astPath.GetLast().OutEdge
 
-			// Update the field path.
-			switch edge := astPathEdge.(type) {
-			case *StructFieldEdge:
-				ctx.appendFieldPath(NewFieldName(edge.FieldName))
-			case *ArrayElementEdge:
-				ctx.appendFieldPath(NewArrayElement(edge.ElementIndex))
-			case *MapValueEdge:
-				ctx.appendFieldPath(NewFieldName(fmt.Sprint(edge.MapKey)))
-			default:
-				panic(fmt.Sprintf("unknown edge type: %v", edge))
+				// Update the field path.
+				switch edge := astPathEdge.(type) {
+				case *StructFieldEdge:
+					ctx.appendFieldPath(NewFieldName(edge.FieldName))
+				case *ArrayElementEdge:
+					ctx.appendFieldPath(NewArrayElement(edge.ElementIndex))
+				case *MapValueEdge:
+					ctx.appendFieldPath(NewFieldName(fmt.Sprint(edge.MapKey)))
+				default:
+					panic(fmt.Sprintf("unknown edge type: %v", edge))
+				}
+
+				// Update the REST path.
+				ctx.appendRestPath(astPathEdge.String())
 			}
-
-			// Update the REST path.
-			ctx.appendRestPath(astPathEdge.String())
 		}
 
 		if node.GetOptional() != nil {

--- a/visitors/http_rest_diff/spec_diff_visitor.go
+++ b/visitors/http_rest_diff/spec_diff_visitor.go
@@ -261,7 +261,7 @@ OUTER:
 		}
 	}
 
-	return SkipChildren
+	return Continue
 }
 
 func (*DefaultSpecDiffVisitorImpl) LeaveOneOfs(self interface{}, ctx http_rest.SpecPairVisitorContext, left, right *pb.OneOf, cont Cont) Cont {

--- a/visitors/visitor.go
+++ b/visitors/visitor.go
@@ -39,6 +39,10 @@ type Context interface {
 // Represents a path through a data structure.
 type ContextPath []ContextPathElement
 
+func (c ContextPath) IsEmpty() bool {
+	return len(c) == 0
+}
+
 func (c ContextPath) GetLast() ContextPathElement {
 	return c[len(c)-1]
 }


### PR DESCRIPTION
An array-index-out-of-bounds issue occurred when visiting starts at a Data node that is not a top-level method argument.