### PR TITLE
Ignore requests with 4xx responses during melding

### DIFF
--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -12,11 +12,29 @@ import (
 
 // Melds src into dst, resolving conflicts using oneof. Assumes that dst and src
 // are for the same endpoint.
+//
+// If src contains only 4xx response codes, then the requests in src are
+// ignored because they are likely to be bogus, and only responses are melded.
 func MeldMethod(dst, src *pb.Method) error {
-	if dst.Args == nil {
-		dst.Args = src.Args
-	} else if err := meldTopLevelDataMap(dst.Args, src.Args); err != nil {
-		return errors.Wrap(err, "failed to meld arg map")
+	// Determine whether src has only 4xx response codes.
+	srcHas4xxOnly := false
+	if len(src.Responses) > 0 {
+		srcHas4xxOnly = true
+		for _, response := range src.Responses {
+			responseCode := response.GetMeta().GetHttp().GetResponseCode()
+			if responseCode < 400 || responseCode >= 500 {
+				srcHas4xxOnly = false
+				break
+			}
+		}
+	}
+
+	if !srcHas4xxOnly {
+		if dst.Args == nil {
+			dst.Args = src.Args
+		} else if err := meldTopLevelDataMap(dst.Args, src.Args); err != nil {
+			return errors.Wrap(err, "failed to meld arg map")
+		}
 	}
 
 	if dst.Responses == nil {

--- a/spec_util/testdata/meld/meld_examples_1.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_1.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   args: {
-    key: ""
+    key: "QnFfsGuRnss="
     value: {
       primitive: {
         string_value: {

--- a/spec_util/testdata/meld/meld_examples_4xx.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_4xx.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   args: {
-    key: ""
+    key: "QnFfsGuRnss="
     value: {
       primitive: {
         string_value: {

--- a/spec_util/testdata/meld/meld_examples_4xx.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_4xx.pb.txt
@@ -1,0 +1,61 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file/{arg3}"
+      host: "www.akibox.com"
+    }
+  }
+  args: {
+    key: ""
+    value: {
+      primitive: {
+        string_value: {
+          value: "f1"
+        }
+      }
+      meta: {
+        http: {
+          path: {
+            key: "arg3"
+          }
+        }
+      }
+      example_values: {
+        key: "f2"
+        value: {}
+      }
+    }
+  }
+  responses: {
+    key: "bogus"
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {
+                value: "file_1"
+              }
+              formats: {
+                key: "ISOYearMonthDay"
+                value: true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 403
+        }
+      }
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_examples_4xx.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_4xx.pb.txt
@@ -30,7 +30,7 @@ method: {
     }
   }
   responses: {
-    key: "bogus"
+    key: "ui5EpupUcWM="
     value: {
       struct: {
         fields: {

--- a/spec_util/testdata/meld/meld_from_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_from_4xx_expected.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   args: {
-    key: ""
+    key: "QnFfsGuRnss="
     value: {
       primitive: {
         string_value: {

--- a/spec_util/testdata/meld/meld_from_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_from_4xx_expected.pb.txt
@@ -1,0 +1,90 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file/{arg3}"
+      host: "www.akibox.com"
+    }
+  }
+  args: {
+    key: ""
+    value: {
+      primitive: {
+        string_value: {
+          value: "f1"
+        }
+      }
+      meta: {
+        http: {
+          path: {
+            key: "arg3"
+          }
+        }
+      }
+      example_values: {
+        key: "f1"
+        value: {}
+      }
+    }
+  }
+  responses: {
+    key: "naAThnYPT5A="
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {
+                value: "file_1"
+              }
+              formats: {
+                key: "ISOYearMonth"
+                value: true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+  responses: {
+    key: "bogus"
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {
+                value: "file_1"
+              }
+              formats: {
+                key: "ISOYearMonthDay"
+                value: true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 403
+        }
+      }
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_from_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_from_4xx_expected.pb.txt
@@ -59,7 +59,7 @@ method: {
     }
   }
   responses: {
-    key: "bogus"
+    key: "ui5EpupUcWM="
     value: {
       struct: {
         fields: {

--- a/spec_util/testdata/meld/meld_into_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_into_4xx_expected.pb.txt
@@ -34,7 +34,7 @@ method: {
     }
   }
   responses: {
-    key: "bogus"
+    key: "ui5EpupUcWM="
     value: {
       struct: {
         fields: {

--- a/spec_util/testdata/meld/meld_into_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_into_4xx_expected.pb.txt
@@ -1,0 +1,94 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file/{arg3}"
+      host: "www.akibox.com"
+    }
+  }
+  args: {
+    key: "QnFfsGuRnss="
+    value: {
+      primitive: {
+        string_value: {
+          value: "f1"
+        }
+      }
+      meta: {
+        http: {
+          path: {
+            key: "arg3"
+          }
+        }
+      }
+      example_values: {
+        key: "f2"
+        value: {}
+      }
+      example_values: {
+        key: "f1"
+        value: {}
+      }
+    }
+  }
+  responses: {
+    key: "bogus"
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {
+                value: "file_1"
+              }
+              formats: {
+                key: "ISOYearMonthDay"
+                value: true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 403
+        }
+      }
+    }
+  }
+  responses: {
+    key: "naAThnYPT5A="
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {
+                value: "file_1"
+              }
+              formats: {
+                key: "ISOYearMonth"
+                value: true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
When melding a source `pb.Method` into a destination `pb.Method`, ignore requests in the source if the source has at least one response and all responses have 4xx response codes.