### PR TITLE
Introduce `MeldedMethod`

### DIFF
--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -10,42 +10,6 @@ import (
 	"github.com/akitasoftware/akita-libs/pbhash"
 )
 
-// Melds src into dst, resolving conflicts using oneof. Assumes that dst and src
-// are for the same endpoint.
-//
-// If src contains only 4xx response codes, then the requests in src are
-// ignored because they are likely to be bogus, and only responses are melded.
-func MeldMethod(dst, src *pb.Method) error {
-	// Determine whether src has only 4xx response codes.
-	srcHas4xxOnly := false
-	if len(src.Responses) > 0 {
-		srcHas4xxOnly = true
-		for _, response := range src.Responses {
-			responseCode := response.GetMeta().GetHttp().GetResponseCode()
-			if responseCode < 400 || responseCode >= 500 {
-				srcHas4xxOnly = false
-				break
-			}
-		}
-	}
-
-	if !srcHas4xxOnly {
-		if dst.Args == nil {
-			dst.Args = src.Args
-		} else if err := meldTopLevelDataMap(dst.Args, src.Args); err != nil {
-			return errors.Wrap(err, "failed to meld arg map")
-		}
-	}
-
-	if dst.Responses == nil {
-		dst.Responses = src.Responses
-	} else if err := meldTopLevelDataMap(dst.Responses, src.Responses); err != nil {
-		return errors.Wrap(err, "failed to meld response map")
-	}
-
-	return nil
-}
-
 type dataAndHash struct {
 	hash string
 	data *pb.Data

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -14,7 +14,6 @@ type testData struct {
 	name                string
 	witnessFiles        []string
 	expectedWitnessFile string
-	commutative         bool
 }
 
 var tests = []testData{
@@ -25,7 +24,6 @@ var tests = []testData{
 			"testdata/meld/meld_data_formats_1.pb.txt",
 		},
 		"testdata/meld/meld_data_formats_1.pb.txt",
-		true,
 	},
 	{
 		"format, format",
@@ -34,7 +32,6 @@ var tests = []testData{
 			"testdata/meld/meld_data_formats_2.pb.txt",
 		},
 		"testdata/meld/meld_data_formats_3.pb.txt",
-		true,
 	},
 	{
 		"format, format with conflict",
@@ -43,7 +40,6 @@ var tests = []testData{
 			"testdata/meld/meld_conflict_2.pb.txt",
 		},
 		"testdata/meld/meld_conflict_expected.pb.txt",
-		true,
 	},
 	{
 		"duplicate format dropped",
@@ -54,7 +50,6 @@ var tests = []testData{
 			"testdata/meld/meld_data_formats_2.pb.txt",
 		},
 		"testdata/meld/meld_data_formats_3.pb.txt",
-		true,
 	},
 	{
 		"duplicate format kind dropped",
@@ -65,7 +60,6 @@ var tests = []testData{
 			"testdata/meld/meld_data_kind_2.pb.txt",
 		},
 		"testdata/meld/meld_data_kind_expected.pb.txt",
-		true,
 	},
 	{
 		"meld into existing conflict",
@@ -74,7 +68,6 @@ var tests = []testData{
 			"testdata/meld/meld_with_existing_conflict_2.pb.txt",
 		},
 		"testdata/meld/meld_with_existing_conflict_expected.pb.txt",
-		true,
 	},
 	{
 		"turn conflict with none into optional - order 1",
@@ -83,7 +76,6 @@ var tests = []testData{
 			"testdata/meld/meld_suppress_none_conflict_2.pb.txt",
 		},
 		"testdata/meld/meld_suppress_none_conflict_expected.pb.txt",
-		true,
 	},
 	{
 		// Make sure none is suppressed if it's not the first value that we process.
@@ -93,7 +85,6 @@ var tests = []testData{
 			"testdata/meld/meld_suppress_none_conflict_1.pb.txt",
 		},
 		"testdata/meld/meld_suppress_none_conflict_expected.pb.txt",
-		true,
 	},
 	{
 		// Test meld(T, optional<T>) => optional<T>
@@ -103,7 +94,6 @@ var tests = []testData{
 			"testdata/meld/meld_optional_required_2.pb.txt",
 		},
 		"testdata/meld/meld_optional_required_2.pb.txt",
-		true,
 	},
 	{
 		// meld(oneof(T1, T2), oneof(T1, T3)) => oneof(T1, T2, T3)
@@ -113,7 +103,6 @@ var tests = []testData{
 			"testdata/meld/meld_additive_oneof_2.pb.txt",
 		},
 		"testdata/meld/meld_additive_oneof_expected.pb.txt",
-		true,
 	},
 	{
 		// meld(oneof(T1, T2), T3) => oneof(T1, T2, T3)
@@ -123,7 +112,6 @@ var tests = []testData{
 			"testdata/meld/meld_oneof_with_primitive_2.pb.txt",
 		},
 		"testdata/meld/meld_oneof_with_primitive_expected.pb.txt",
-		true,
 	},
 	{
 		"meld struct",
@@ -132,7 +120,6 @@ var tests = []testData{
 			"testdata/meld/meld_struct_2.pb.txt",
 		},
 		"testdata/meld/meld_struct_2.pb.txt",
-		true,
 	},
 	{
 		"meld list",
@@ -141,7 +128,6 @@ var tests = []testData{
 			"testdata/meld/meld_list_2.pb.txt",
 		},
 		"testdata/meld/meld_list_2.pb.txt",
-		true,
 	},
 	{
 		"example, example",
@@ -150,7 +136,6 @@ var tests = []testData{
 			"testdata/meld/meld_examples_2.pb.txt",
 		},
 		"testdata/meld/meld_examples_3.pb.txt",
-		true,
 	},
 	{
 		"3 examples, 3 examples",
@@ -159,7 +144,6 @@ var tests = []testData{
 			"testdata/meld/meld_examples_big_2.pb.txt",
 		},
 		"testdata/meld/meld_examples_big_3.pb.txt",
-		true,
 	},
 	{
 		"1 example, 0 examples",
@@ -168,56 +152,72 @@ var tests = []testData{
 			"testdata/meld/meld_no_examples_2.pb.txt",
 		},
 		"testdata/meld/meld_no_examples_3.pb.txt",
-		true,
 	},
-	// Test melding non-4xx into 4xx.
+	// Test melding non-4xx with 4xx.
 	{
 		"4xx example, example",
 		[]string{
-			"testdata/meld/meld_examples_4xx.pb.txt",
 			"testdata/meld/meld_examples_1.pb.txt",
+			"testdata/meld/meld_examples_4xx_2.pb.txt",
 		},
-		"testdata/meld/meld_into_4xx_expected.pb.txt",
-		false,
+		"testdata/meld/meld_non_4xx_with_4xx_expected.pb.txt",
 	},
-	// Test melding 4xx into non-4xx.
+	// Test melding 4xx with 4xx.
 	{
-		"example, 4xx example",
+		"4xx example, 4xx example",
 		[]string{
-			"testdata/meld/meld_examples_1.pb.txt",
-			"testdata/meld/meld_examples_4xx.pb.txt",
+			"testdata/meld/meld_examples_4xx_1.pb.txt",
+			"testdata/meld/meld_examples_4xx_2.pb.txt",
 		},
-		"testdata/meld/meld_from_4xx_expected.pb.txt",
-		false,
+		"testdata/meld/meld_4xx_expected.pb.txt",
+	},
+	// Test melding request-only with 4xx. We should get the request from the first, paired with the response from the second.
+	{
+		"no response, 4xx example",
+		[]string{
+			"testdata/meld/meld_no_response.pb.txt",
+			"testdata/meld/meld_examples_4xx_2.pb.txt",
+		},
+		"testdata/meld/meld_no_response_4xx_expected.pb.txt",
+	},
+	// Test melding request-only with 4xx with 4xx and non-4xx. We should get the requests from the first and third, paired with both responses.
+	{
+		"no response, 4xx example, full non-4xx",
+		[]string{
+			"testdata/meld/meld_no_response.pb.txt",
+			"testdata/meld/meld_examples_4xx_2.pb.txt",
+			"testdata/meld/meld_examples_2.pb.txt",
+		},
+		"testdata/meld/meld_no_response_4xx_non_4xx_expected.pb.txt",
 	},
 }
 
 func TestMeldWithFormats(t *testing.T) {
 	for _, testData := range tests {
-		expected := test.LoadWitnessFromFileOrDile(testData.expectedWitnessFile)
+		expected := test.LoadWitnessFromFileOrDile(testData.expectedWitnessFile).Method
 
 		// test right merged to left
 		{
-			result := test.LoadWitnessFromFileOrDile(testData.witnessFiles[0])
+			result := NewMeldedMethod(test.LoadWitnessFromFileOrDile(testData.witnessFiles[0]).Method)
 			for i := 1; i < len(testData.witnessFiles); i++ {
 				newWitness := test.LoadWitnessFromFileOrDile(testData.witnessFiles[i])
-				assert.NoError(t, MeldMethod(result.Method, newWitness.Method))
+				assert.NoError(t, result.Meld(NewMeldedMethod(newWitness.Method)))
 			}
-			if diff := cmp.Diff(expected, result, cmp.Comparer(proto.Equal)); diff != "" {
+			if diff := cmp.Diff(expected, result.GetMethod(), cmp.Comparer(proto.Equal)); diff != "" {
 				t.Errorf("[%s] right merged to left\n%v", testData.name, diff)
 				continue
 			}
 		}
 
 		// test left merged to right
-		if testData.commutative {
+		{
 			l := len(testData.witnessFiles)
-			result := test.LoadWitnessFromFileOrDile(testData.witnessFiles[l-1])
+			result := NewMeldedMethod(test.LoadWitnessFromFileOrDile(testData.witnessFiles[l-1]).Method)
 			for i := l - 2; i >= 0; i-- {
 				newWitness := test.LoadWitnessFromFileOrDile(testData.witnessFiles[i])
-				assert.NoError(t, MeldMethod(result.Method, newWitness.Method))
+				assert.NoError(t, result.Meld(NewMeldedMethod(newWitness.Method)))
 			}
-			if diff := cmp.Diff(expected, result, cmp.Comparer(proto.Equal)); diff != "" {
+			if diff := cmp.Diff(expected, result.GetMethod(), cmp.Comparer(proto.Equal)); diff != "" {
 				t.Errorf("[%s] left merged to right\n%v", testData.name, diff)
 				continue
 			}

--- a/spec_util/melded_method.go
+++ b/spec_util/melded_method.go
@@ -1,0 +1,125 @@
+package spec_util
+
+import (
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+)
+
+type MeldedMethod interface {
+	GetMethod() *pb.Method
+
+	GetArgs() map[string]*pb.Data
+	SetArgs(map[string]*pb.Data)
+
+	GetResponses() map[string]*pb.Data
+	SetResponses(map[string]*pb.Data)
+
+	Has4xxOnly() bool
+	SetHas4xxOnly(bool)
+	Clone() MeldedMethod
+
+	// Melds src into this instance, resolving conflicts using oneof. Assumes that this and src are for the same endpoint.
+	//
+	// Responses are always melded. But because they are likely to contain bogus data, requests that result in 4xx response codes are ignored where possible:
+	//   - If both src and this contain only 4xx responses, then requests are melded.
+	//   - Otherwise, if src contains only 4xx responses, then its requests are ignored.
+	//   - Otherwise, if this contains only 4xx responses, then its requests are replaced with requests from src.
+	//   - Otherwise, neither src nor this contain only 4xx responses, and requests are melded.
+	Meld(src MeldedMethod) error
+}
+
+type meldedMethod struct {
+	method *pb.Method
+
+	// Indicates whether the method has only requests that received a 4xx response code.
+	has4xxOnly bool
+}
+
+var _ MeldedMethod = (*meldedMethod)(nil)
+
+func NewMeldedMethod(method *pb.Method) MeldedMethod {
+	return &meldedMethod{
+		method:     method,
+		has4xxOnly: hasOnly4xxResponses(method),
+	}
+}
+
+func (m *meldedMethod) GetMethod() *pb.Method {
+	return m.method
+}
+
+func (m *meldedMethod) GetArgs() map[string]*pb.Data {
+	return m.method.GetArgs()
+}
+
+func (m *meldedMethod) SetArgs(args map[string]*pb.Data) {
+	m.method.Args = args
+}
+
+func (m *meldedMethod) GetResponses() map[string]*pb.Data {
+	return m.method.GetResponses()
+}
+
+func (m *meldedMethod) SetResponses(responses map[string]*pb.Data) {
+	m.method.Responses = responses
+}
+
+func (m *meldedMethod) Has4xxOnly() bool {
+	return m.has4xxOnly
+}
+
+func (m *meldedMethod) SetHas4xxOnly(b bool) {
+	m.has4xxOnly = b
+}
+
+func (m *meldedMethod) Clone() MeldedMethod {
+	return &meldedMethod{
+		method:     proto.Clone(m.method).(*pb.Method),
+		has4xxOnly: m.has4xxOnly,
+	}
+}
+
+func (dst *meldedMethod) Meld(src MeldedMethod) error {
+	if !src.Has4xxOnly() && dst.has4xxOnly {
+		// Replace dst requests with src requests.
+		dst.method.Args = src.GetArgs()
+		dst.has4xxOnly = false
+	} else if src.Has4xxOnly() && !dst.has4xxOnly {
+		// Ignore src requests.
+	} else {
+		// Meld requests.
+		if dst.method.Args == nil {
+			dst.method.Args = src.GetArgs()
+		} else if err := meldTopLevelDataMap(dst.method.Args, src.GetArgs()); err != nil {
+			return errors.Wrap(err, "failed to meld arg map")
+		}
+		dst.has4xxOnly = dst.has4xxOnly && src.Has4xxOnly()
+	}
+
+	// Meld responses.
+	if dst.method.Responses == nil {
+		dst.method.Responses = src.GetResponses()
+	} else if err := meldTopLevelDataMap(dst.method.Responses, src.GetResponses()); err != nil {
+		return errors.Wrap(err, "failed to meld response map")
+	}
+
+	return nil
+}
+
+// Determines whether a given method has only 4xx response codes. Returns true if the method has at least one response and all response codes are 4xx.
+func hasOnly4xxResponses(method *pb.Method) bool {
+	responses := method.GetResponses()
+	if len(responses) == 0 {
+		return false
+	}
+
+	for _, response := range responses {
+		responseCode := response.Meta.GetHttp().GetResponseCode()
+		if responseCode < 400 || responseCode >= 500 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/spec_util/testdata/meld/meld_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_4xx_expected.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   args: {
-    key: ""
+    key: "QnFfsGuRnss="
     value: {
       primitive: {
         string_value: {
@@ -27,10 +27,14 @@ method: {
         key: "f2"
         value: {}
       }
+      example_values: {
+        key: "f1"
+        value: {}
+      }
     }
   }
   responses: {
-    key: "oFUqCcv3wkM="
+    key: "UkEwED5h2s0="
     value: {
       struct: {
         fields: {
@@ -39,6 +43,10 @@ method: {
             primitive: {
               string_value: {
                 value: "file_1"
+              }
+              formats: {
+                key: "ISOYearMonth"
+                value: true
               }
               formats: {
                 key: "ISOYearMonthDay"
@@ -53,7 +61,7 @@ method: {
           body: {
             content_type: JSON
           }
-          response_code: 200
+          response_code: 403
         }
       }
     }

--- a/spec_util/testdata/meld/meld_examples_4xx_1.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_4xx_1.pb.txt
@@ -24,46 +24,13 @@ method: {
         }
       }
       example_values: {
-        key: "f2"
-        value: {}
-      }
-      example_values: {
         key: "f1"
         value: {}
       }
     }
   }
   responses: {
-    key: "ui5EpupUcWM="
-    value: {
-      struct: {
-        fields: {
-          key: "name"
-          value: {
-            primitive: {
-              string_value: {
-                value: "file_1"
-              }
-              formats: {
-                key: "ISOYearMonthDay"
-                value: true
-              }
-            }
-          }
-        }
-      }
-      meta: {
-        http: {
-          body: {
-            content_type: JSON
-          }
-          response_code: 403
-        }
-      }
-    }
-  }
-  responses: {
-    key: "naAThnYPT5A="
+    key: "ugh"
     value: {
       struct: {
         fields: {
@@ -86,7 +53,7 @@ method: {
           body: {
             content_type: JSON
           }
-          response_code: 200
+          response_code: 403
         }
       }
     }

--- a/spec_util/testdata/meld/meld_examples_4xx_2.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_4xx_2.pb.txt
@@ -30,7 +30,7 @@ method: {
     }
   }
   responses: {
-    key: "oFUqCcv3wkM="
+    key: "ui5EpupUcWM="
     value: {
       struct: {
         fields: {
@@ -53,7 +53,7 @@ method: {
           body: {
             content_type: JSON
           }
-          response_code: 200
+          response_code: 403
         }
       }
     }

--- a/spec_util/testdata/meld/meld_no_response.pb.txt
+++ b/spec_util/testdata/meld/meld_no_response.pb.txt
@@ -1,0 +1,32 @@
+# api_spec.Witness proto
+
+method: {
+  meta: {
+    http: {
+      method: "POST"
+      path_template: "/api/create_file/{arg3}"
+      host: "www.akibox.com"
+    }
+  }
+  args: {
+    key: "QnFfsGuRnss="
+    value: {
+      primitive: {
+        string_value: {
+          value: "f1"
+        }
+      }
+      meta: {
+        http: {
+          path: {
+            key: "arg3"
+          }
+        }
+      }
+      example_values: {
+        key: "f1"
+        value: {}
+      }
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_no_response_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_no_response_4xx_expected.pb.txt
@@ -24,7 +24,7 @@ method: {
         }
       }
       example_values: {
-        key: "f2"
+        key: "f1"
         value: {}
       }
     }

--- a/spec_util/testdata/meld/meld_no_response_4xx_non_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_no_response_4xx_non_4xx_expected.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   args: {
-    key: ""
+    key: "QnFfsGuRnss="
     value: {
       primitive: {
         string_value: {
@@ -22,6 +22,10 @@ method: {
             key: "arg3"
           }
         }
+      }
+      example_values: {
+        key: "f1"
+        value: {}
       }
       example_values: {
         key: "f2"
@@ -54,6 +58,35 @@ method: {
             content_type: JSON
           }
           response_code: 200
+        }
+      }
+    }
+  }
+  responses: {
+    key: "ui5EpupUcWM="
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {
+                value: "file_1"
+              }
+              formats: {
+                key: "ISOYearMonthDay"
+                value: true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 403
         }
       }
     }

--- a/spec_util/testdata/meld/meld_non_4xx_with_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_non_4xx_with_4xx_expected.pb.txt
@@ -30,35 +30,6 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
-    value: {
-      struct: {
-        fields: {
-          key: "name"
-          value: {
-            primitive: {
-              string_value: {
-                value: "file_1"
-              }
-              formats: {
-                key: "ISOYearMonth"
-                value: true
-              }
-            }
-          }
-        }
-      }
-      meta: {
-        http: {
-          body: {
-            content_type: JSON
-          }
-          response_code: 200
-        }
-      }
-    }
-  }
-  responses: {
     key: "ui5EpupUcWM="
     value: {
       struct: {
@@ -83,6 +54,35 @@ method: {
             content_type: JSON
           }
           response_code: 403
+        }
+      }
+    }
+  }
+  responses: {
+    key: "naAThnYPT5A="
+    value: {
+      struct: {
+        fields: {
+          key: "name"
+          value: {
+            primitive: {
+              string_value: {
+                value: "file_1"
+              }
+              formats: {
+                key: "ISOYearMonth"
+                value: true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type: JSON
+          }
+          response_code: 200
         }
       }
     }


### PR DESCRIPTION
A `MeldedMethod` tracks the provenance of its components. Without it, we are unable to determine the difference between:
  - a method that contains a request and its corresponding 4xx response, and
  - the result of melding (1) a method that contains a request with no response and (2) a method that contains a request and its corresponding 4xx response.

In the second scenario, the melded method contains the bare request (because it might contain useful information) and the 4xx response (but not its request, which is likely bogus). We wish to retain all aspects of this melded method when doing further melds, whereas when melding the method in the first scenario, we might drop its request. However, these two are indistinguishable, unless we are able to track the provenance of the components in a melded method.

See the "no response, 4xx example, full non-4xx" test case in `spec_util/meld_test.go`.