### PR TITLE
Add a type for tag keys

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -57,7 +57,7 @@ type CreateLearnSessionRequest struct {
 	BaseAPISpecRef *APISpecReference `json:"base_api_spec_ref,omitempty"`
 
 	// Optional key-value pairs to tag this learn session.
-	// We reserve tags with "x-akita" and "akita:" prefix for internal use.
+	// We reserve tags with "x-akita-" prefix for internal use.
 	Tags map[tags.Key]string `json:"tags,omitempty"`
 
 	// Optional name for the learn session.

--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/spec_summary"
+	"github.com/akitasoftware/akita-libs/tags"
 )
 
 // NetworkDirection is always relative to subject service.
@@ -56,8 +57,8 @@ type CreateLearnSessionRequest struct {
 	BaseAPISpecRef *APISpecReference `json:"base_api_spec_ref,omitempty"`
 
 	// Optional key-value pairs to tag this learn session.
-	// We reserve tags with "x-akita" prefix for internal use.
-	Tags map[string]string `json:"tags,omitempty"`
+	// We reserve tags with "x-akita" and "akita:" prefix for internal use.
+	Tags map[tags.Key]string `json:"tags,omitempty"`
 
 	// Optional name for the learn session.
 	Name string `json:"name"`

--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -98,12 +98,12 @@ type CreateSpecRequest struct {
 	Name string `json:"name"`
 
 	// Optional: user-specified tags.
-	Tags map[string]string `json:"tags"`
+	Tags map[tags.Key]string `json:"tags"`
 }
 
 type UploadSpecRequest struct {
-	Name string            `json:"name"`
-	Tags map[string]string `json:"tags,omitempty"`
+	Name string              `json:"name"`
+	Tags map[tags.Key]string `json:"tags,omitempty"`
 
 	// TODO(kku): use multipart/form-data upload once we can support it.
 	Content string `json:"content"`
@@ -134,8 +134,8 @@ type WitnessReport struct {
 	// A serialized Witness protobuf in base64 URL encoded format.
 	WitnessProto string `json:"witness_proto"`
 
-	ID   akid.WitnessID    `json:"id"`
-	Tags map[string]string `json:"tags"`
+	ID   akid.WitnessID      `json:"id"`
+	Tags map[tags.Key]string `json:"tags"`
 
 	// Hash of the witness proto. Only used internally in the client.
 	Hash string `json:"-"`
@@ -159,7 +159,7 @@ type GetSpecMetadataResponse struct {
 
 	State APISpecState `json:"state"`
 
-	Tags map[string]string `json:"tags"`
+	Tags map[tags.Key]string `json:"tags"`
 }
 
 type GetSpecResponse struct {
@@ -180,7 +180,7 @@ type GetSpecResponse struct {
 
 	Summary *spec_summary.Summary `json:"summary,omitempty"`
 
-	Tags map[string]string `json:"tags"`
+	Tags map[tags.Key]string `json:"tags"`
 }
 
 type SetSpecVersionRequest struct {

--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -86,7 +86,7 @@ type LearnSessionTag struct {
 	tableName struct{} `pg:"learn_session_tags"`
 
 	LearnSessionID akid.LearnSessionID `pg:"learn_session_id" json:"learn_session_id"`
-	Key            string              `pg:"key" json:"key"`
+	Key            tags.Key            `pg:"key" json:"key"`
 	Value          string              `pg:"value,use_zero" json:"value"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,5 @@ require (
 
 replace (
 	github.com/google/gopacket v1.1.18 => github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293
-	github.com/google/martian/v3 v3.0.1 => github.com/akitasoftware/martian/v3 v3.0.1-0.20210607230525-1acfb608de0d
+	github.com/google/martian/v3 v3.0.1 => github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de
 )

--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,5 @@ require (
 
 replace (
 	github.com/google/gopacket v1.1.18 => github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293
-	github.com/google/martian/v3 v3.0.1 => github.com/akitasoftware/martian/v3 v3.0.1-0.20210408175823-8159a63604a0
+	github.com/google/martian/v3 v3.0.1 => github.com/akitasoftware/martian/v3 v3.0.1-0.20210607215513-d8717bec3637
 )

--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,5 @@ require (
 
 replace (
 	github.com/google/gopacket v1.1.18 => github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293
-	github.com/google/martian/v3 v3.0.1 => github.com/akitasoftware/martian/v3 v3.0.1-0.20210607215513-d8717bec3637
+	github.com/google/martian/v3 v3.0.1 => github.com/akitasoftware/martian/v3 v3.0.1-0.20210607230525-1acfb608de0d
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/akitasoftware/martian/v3 v3.0.1-0.20210408175823-8159a63604a0 h1:I6dM
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210408175823-8159a63604a0/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210607215513-d8717bec3637 h1:RsGofPPzDUAg+iYDd+N8l+YFhWSihp6ca0rW8bP7MPw=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210607215513-d8717bec3637/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
+github.com/akitasoftware/martian/v3 v3.0.1-0.20210607230525-1acfb608de0d h1:G4DBVe2XdmNQWgzWI2M5pycWVJE9nRrGJz9/csxai34=
+github.com/akitasoftware/martian/v3 v3.0.1-0.20210607230525-1acfb608de0d/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba h1:sAv1pLJk8VU9q8CddBocaftsZnb2ppbBEQSN6H5O3kg=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba/go.mod h1:otNn0Cq1YGR1daOez6qwaCaF9tzRk1YkIsxF+6faKNE=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPB
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210408175823-8159a63604a0 h1:I6dMrqlMXbXKpCQUCXKif6eT2FbG9GiXtGTUgBAJHlQ=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210408175823-8159a63604a0/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
+github.com/akitasoftware/martian/v3 v3.0.1-0.20210607215513-d8717bec3637 h1:RsGofPPzDUAg+iYDd+N8l+YFhWSihp6ca0rW8bP7MPw=
+github.com/akitasoftware/martian/v3 v3.0.1-0.20210607215513-d8717bec3637/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba h1:sAv1pLJk8VU9q8CddBocaftsZnb2ppbBEQSN6H5O3kg=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba/go.mod h1:otNn0Cq1YGR1daOez6qwaCaF9tzRk1YkIsxF+6faKNE=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/akitasoftware/martian/v3 v3.0.1-0.20210607215513-d8717bec3637 h1:RsGo
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210607215513-d8717bec3637/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210607230525-1acfb608de0d h1:G4DBVe2XdmNQWgzWI2M5pycWVJE9nRrGJz9/csxai34=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210607230525-1acfb608de0d/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
+github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=
+github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba h1:sAv1pLJk8VU9q8CddBocaftsZnb2ppbBEQSN6H5O3kg=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba/go.mod h1:otNn0Cq1YGR1daOez6qwaCaF9tzRk1YkIsxF+6faKNE=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/tags/reserved_tags.go
+++ b/tags/reserved_tags.go
@@ -10,11 +10,7 @@ import (
 type Key = tags.Key
 
 const (
-	// Identifies the source of a trace or spec. Valid values:
-	//   - user - trace/spec was manually created by a user
-	//   - uploaded - trace/spec was manually uploaded by a user
-	//   - deployment - trace/spec from a staging or production deployment
-	//   - ci - trace/spec from a CI pipeline
+	// Identifies the source of a trace or spec. See `Source` for values.
 	XAkitaSource Key = "x-akita-source"
 
 	// The original filesystem path of an uploaded trace.
@@ -63,10 +59,6 @@ const (
 
 // GitHub tags
 const (
-	// Identifies the GitHub organization in which the pull request was made.
-	// Attached to traces or specs obtained from a GitHub pull request.
-	AkitaGitHubOrganizationID Key = "x-akita-github-organization-id"
-
 	// Identifies the GitHub PR number associated with the pull request. Attached
 	// to traces or specs obtained from a GitHub pull request.
 	XAkitaGitHubPR Key = "x-akita-github-pr"

--- a/tags/reserved_tags.go
+++ b/tags/reserved_tags.go
@@ -1,0 +1,118 @@
+package tags
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type Key string
+
+// Identifies the source of a trace or spec. Valid values:
+//   - user - trace/spec was manually created by a user
+//   - uploaded - trace/spec was manually uploaded by a user
+//   - deployment - trace/spec from a staging or production deployment
+//   - ci - trace/spec from a CI pipeline
+const XAkitaSource Key = "x-akita-source"
+
+// The original filesystem path of an uploaded trace.
+const XAkitaTraceLocalPath Key = "x-akita-trace-local-path"
+
+// == Generic CI tags =========================================================
+
+// Identifies the CI framework from which a trace or spec was obtained (e.g.,
+// CircleCI, Travis).
+const XAkitaCI Key = "x-akita-ci"
+
+// == CircleCI tags ===========================================================
+
+// The contents of the CIRCLE_BUILD_URL environment variable. Attached to
+// traces and specs derived from a CircleCI job.
+const XAkitaCircleCIBuildURL Key = "x-akita-circleci-build-url"
+
+// == Travis tags =============================================================
+
+// The contents of the TRAVIS_BUILD_WEB_URL environment variable. Attached to
+// traces and specs derived from a Travis job.
+const XAkitaTravisBuildWebURL Key = "x-akita-travis-build-web-url"
+
+// The contents of the TRAVIS_JOB_WEB_URL environment variable. Attached to
+// traces and specs derived from a Travis job.
+const XAkitaTravisJobWebURL Key = "x-akita-travis-job-web-url"
+
+// == Generic git tags ========================================================
+
+// Identifies the git branch from which the trace or spec was derived. Attached
+// to traces or specs obtained from CI.
+const XAkitaGitBranch Key = "x-akita-git-branch"
+
+// Identifies the git commit hash from which the trace or spec was derived.
+// Attached to traces or specs obtained from CI.
+const XAkitaGitCommit Key = "x-akita-git-commit"
+
+// A link to the git repository. Attached to traces or specs obtained from a
+// pull/merge request.
+const XAkitaGitRepoURL Key = "x-akita-git-repo-url"
+
+// == GitHub tags =============================================================
+
+// Identifies the GitHub organization in which the pull request was made.
+// Attached to traces or specs obtained from a GitHub pull request.
+const AkitaGitHubOrganizationID Key = "x-akita-github-organization-id"
+
+// Identifies the GitHub PR number associated with the pull request. Attached
+// to traces or specs obtained from a GitHub pull request.
+const XAkitaGitHubPR Key = "x-akita-github-pr"
+
+// A link to the GitHub pull request. Attached to traces or specs obtained
+// from a GitHub pull request.
+const XAkitaGitHubPRURL Key = "x-akita-github-pr-url"
+
+// Identifies the GitHub repository for which the pull request was made.
+// Attached to traces or specs obtained from a GitHub pull request.
+const XAkitaGitHubRepo Key = "x-akita-github-repo"
+
+// == GitLab tags =============================================================
+
+const XAkitaGitLabProject Key = "x-akita-gitlab-project"
+const XAkitaGitLabMRIID Key = "x-akita-gitlab-mr-iid"
+
+// == Methods =================================================================
+
+// Determines whether a key is reserved for Akita internal use.
+func (k Key) IsReserved() bool {
+	s := strings.ToLower(string(k))
+	return strings.HasPrefix(s, "x-akita-")
+}
+
+// Returns an error if the key is reserved for Akita internal use.
+func (k Key) CheckReserved() error {
+	if !k.IsReserved() {
+		return nil
+	}
+
+	return errors.New(`Tags starting with "x-akita-" are reserved for Akita internal use.`)
+}
+
+// Returns a map from parsing a list of "key=value" pairs.
+func FromPairs(pairs []string) (map[Key]string, error) {
+	results := make(map[Key]string, len(pairs))
+	for _, p := range pairs {
+		parts := strings.Split(p, "=")
+		if len(parts) != 2 {
+			return nil, errors.Errorf("%s is not a valid key=value format", p)
+		}
+
+		k, v := Key(parts[0]), parts[1]
+		if _, ok := results[k]; ok {
+			return nil, errors.Errorf("tag with key %s specified more than once", k)
+		}
+
+		if err := k.CheckReserved(); err != nil {
+			return nil, err
+		}
+
+		results[k] = v
+	}
+	return results, nil
+}

--- a/tags/reserved_tags.go
+++ b/tags/reserved_tags.go
@@ -3,10 +3,11 @@ package tags
 import (
 	"strings"
 
+	"github.com/google/martian/v3/tags"
 	"github.com/pkg/errors"
 )
 
-type Key string
+type Key = tags.Key
 
 // Identifies the source of a trace or spec. Valid values:
 //   - user - trace/spec was manually created by a user
@@ -80,14 +81,14 @@ const XAkitaGitLabMRIID Key = "x-akita-gitlab-mr-iid"
 // == Methods =================================================================
 
 // Determines whether a key is reserved for Akita internal use.
-func (k Key) IsReserved() bool {
+func IsReservedKey(k Key) bool {
 	s := strings.ToLower(string(k))
 	return strings.HasPrefix(s, "x-akita-")
 }
 
 // Returns an error if the key is reserved for Akita internal use.
-func (k Key) CheckReserved() error {
-	if !k.IsReserved() {
+func CheckReservedKey(k Key) error {
+	if !IsReservedKey(k) {
 		return nil
 	}
 
@@ -108,7 +109,7 @@ func FromPairs(pairs []string) (map[Key]string, error) {
 			return nil, errors.Errorf("tag with key %s specified more than once", k)
 		}
 
-		if err := k.CheckReserved(); err != nil {
+		if err := CheckReservedKey(k); err != nil {
 			return nil, err
 		}
 

--- a/tags/reserved_tags.go
+++ b/tags/reserved_tags.go
@@ -3,11 +3,8 @@ package tags
 import (
 	"strings"
 
-	"github.com/google/martian/v3/tags"
 	"github.com/pkg/errors"
 )
-
-type Key = tags.Key
 
 const (
 	// Identifies the source of a trace or spec. See `Source` for values.
@@ -100,27 +97,4 @@ func CheckReservedKey(k Key) error {
 	}
 
 	return errors.New(`Tags starting with "x-akita-" are reserved for Akita internal use.`)
-}
-
-// Returns a map from parsing a list of "key=value" pairs.
-func FromPairs(pairs []string) (map[Key]string, error) {
-	results := make(map[Key]string, len(pairs))
-	for _, p := range pairs {
-		parts := strings.Split(p, "=")
-		if len(parts) != 2 {
-			return nil, errors.Errorf("%s is not a valid key=value format", p)
-		}
-
-		k, v := Key(parts[0]), parts[1]
-		if _, ok := results[k]; ok {
-			return nil, errors.Errorf("tag with key %s specified more than once", k)
-		}
-
-		if err := CheckReservedKey(k); err != nil {
-			return nil, err
-		}
-
-		results[k] = v
-	}
-	return results, nil
 }

--- a/tags/reserved_tags.go
+++ b/tags/reserved_tags.go
@@ -9,76 +9,91 @@ import (
 
 type Key = tags.Key
 
-// Identifies the source of a trace or spec. Valid values:
-//   - user - trace/spec was manually created by a user
-//   - uploaded - trace/spec was manually uploaded by a user
-//   - deployment - trace/spec from a staging or production deployment
-//   - ci - trace/spec from a CI pipeline
-const XAkitaSource Key = "x-akita-source"
+const (
+	// Identifies the source of a trace or spec. Valid values:
+	//   - user - trace/spec was manually created by a user
+	//   - uploaded - trace/spec was manually uploaded by a user
+	//   - deployment - trace/spec from a staging or production deployment
+	//   - ci - trace/spec from a CI pipeline
+	XAkitaSource Key = "x-akita-source"
 
-// The original filesystem path of an uploaded trace.
-const XAkitaTraceLocalPath Key = "x-akita-trace-local-path"
+	// The original filesystem path of an uploaded trace.
+	XAkitaTraceLocalPath Key = "x-akita-trace-local-path"
+)
 
-// == Generic CI tags =========================================================
+// Generic CI tags
+const (
+	// Identifies the CI framework from which a trace or spec was obtained (e.g.,
+	// CircleCI, Travis).
+	XAkitaCI Key = "x-akita-ci"
+)
 
-// Identifies the CI framework from which a trace or spec was obtained (e.g.,
-// CircleCI, Travis).
-const XAkitaCI Key = "x-akita-ci"
+// CircleCI tags
+const (
+	// The contents of the CIRCLE_BUILD_URL environment variable. Attached to
+	// traces and specs derived from a CircleCI job.
+	XAkitaCircleCIBuildURL Key = "x-akita-circleci-build-url"
+)
 
-// == CircleCI tags ===========================================================
+// Travis tags
+const (
+	// The contents of the TRAVIS_BUILD_WEB_URL environment variable. Attached to
+	// traces and specs derived from a Travis job.
+	XAkitaTravisBuildWebURL Key = "x-akita-travis-build-web-url"
 
-// The contents of the CIRCLE_BUILD_URL environment variable. Attached to
-// traces and specs derived from a CircleCI job.
-const XAkitaCircleCIBuildURL Key = "x-akita-circleci-build-url"
+	// The contents of the TRAVIS_JOB_WEB_URL environment variable. Attached to
+	// traces and specs derived from a Travis job.
+	XAkitaTravisJobWebURL Key = "x-akita-travis-job-web-url"
+)
 
-// == Travis tags =============================================================
+// Generic git tags
+const (
+	// Identifies the git branch from which the trace or spec was derived.
+	// Attached to traces or specs obtained from CI.
+	XAkitaGitBranch Key = "x-akita-git-branch"
 
-// The contents of the TRAVIS_BUILD_WEB_URL environment variable. Attached to
-// traces and specs derived from a Travis job.
-const XAkitaTravisBuildWebURL Key = "x-akita-travis-build-web-url"
+	// Identifies the git commit hash from which the trace or spec was derived.
+	// Attached to traces or specs obtained from CI.
+	XAkitaGitCommit Key = "x-akita-git-commit"
 
-// The contents of the TRAVIS_JOB_WEB_URL environment variable. Attached to
-// traces and specs derived from a Travis job.
-const XAkitaTravisJobWebURL Key = "x-akita-travis-job-web-url"
+	// A link to the git repository. Attached to traces or specs obtained from a
+	// pull/merge request.
+	XAkitaGitRepoURL Key = "x-akita-git-repo-url"
+)
 
-// == Generic git tags ========================================================
+// GitHub tags
+const (
+	// Identifies the GitHub organization in which the pull request was made.
+	// Attached to traces or specs obtained from a GitHub pull request.
+	AkitaGitHubOrganizationID Key = "x-akita-github-organization-id"
 
-// Identifies the git branch from which the trace or spec was derived. Attached
-// to traces or specs obtained from CI.
-const XAkitaGitBranch Key = "x-akita-git-branch"
+	// Identifies the GitHub PR number associated with the pull request. Attached
+	// to traces or specs obtained from a GitHub pull request.
+	XAkitaGitHubPR Key = "x-akita-github-pr"
 
-// Identifies the git commit hash from which the trace or spec was derived.
-// Attached to traces or specs obtained from CI.
-const XAkitaGitCommit Key = "x-akita-git-commit"
+	// A link to the GitHub pull request. Attached to traces or specs obtained
+	// from a GitHub pull request.
+	XAkitaGitHubPRURL Key = "x-akita-github-pr-url"
 
-// A link to the git repository. Attached to traces or specs obtained from a
-// pull/merge request.
-const XAkitaGitRepoURL Key = "x-akita-git-repo-url"
+	// Identifies the GitHub repository for which the pull request was made.
+	// Attached to traces or specs obtained from a GitHub pull request.
+	XAkitaGitHubRepo Key = "x-akita-github-repo"
+)
 
-// == GitHub tags =============================================================
+// GitLab tags
+const (
+	XAkitaGitLabProject Key = "x-akita-gitlab-project"
+	XAkitaGitLabMRIID   Key = "x-akita-gitlab-mr-iid"
+)
 
-// Identifies the GitHub organization in which the pull request was made.
-// Attached to traces or specs obtained from a GitHub pull request.
-const AkitaGitHubOrganizationID Key = "x-akita-github-organization-id"
+// Packet-capture tags
+const (
+	// A comma-separated list of interfaces on which packets were captured.
+	XAkitaDumpInterfacesFlag Key = "x-akita-dump-interfaces-flag"
 
-// Identifies the GitHub PR number associated with the pull request. Attached
-// to traces or specs obtained from a GitHub pull request.
-const XAkitaGitHubPR Key = "x-akita-github-pr"
-
-// A link to the GitHub pull request. Attached to traces or specs obtained
-// from a GitHub pull request.
-const XAkitaGitHubPRURL Key = "x-akita-github-pr-url"
-
-// Identifies the GitHub repository for which the pull request was made.
-// Attached to traces or specs obtained from a GitHub pull request.
-const XAkitaGitHubRepo Key = "x-akita-github-repo"
-
-// == GitLab tags =============================================================
-
-const XAkitaGitLabProject Key = "x-akita-gitlab-project"
-const XAkitaGitLabMRIID Key = "x-akita-gitlab-mr-iid"
-
-// == Methods =================================================================
+	// The packet filter given on the command line to capture packets.
+	XAkitaDumpFilterFlag Key = "x-akita-dump-filter-flag"
+)
 
 // Determines whether a key is reserved for Akita internal use.
 func IsReservedKey(k Key) bool {

--- a/tags/sources.go
+++ b/tags/sources.go
@@ -1,0 +1,21 @@
+package tags
+
+type Source = string
+
+// Valid values for the XAkitaSource tag.
+const (
+	// Designates a trace or spec that was generated from CI.
+	CISource Source = "ci"
+
+	// Designates a trace or spec that was derived from a staging or production
+	// deployment.
+	DeploymentSource Source = "deployment"
+
+	// Designates a trace or spec that whas manually uploaded by the user.
+	UploadedSource Source = "uploaded"
+
+	// Designates a trace or spec that was manually created by the user. For
+	// example, traces captured from network traffic using the CLI's `apidump`
+	// command are tagged with this source.
+	UserSource Source = "user"
+)

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -1,0 +1,36 @@
+package tags
+
+import (
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/google/martian/v3/tags"
+	"github.com/pkg/errors"
+)
+
+type Key = tags.Key
+
+// Returns a map from parsing a list of "key=value" pairs. Emits a warning if
+// any key in the given list is reserved. Produces an error if any element of
+// the list is improperly formatted, or if any key is given more than once.
+func FromPairs(pairs []string) (map[Key]string, error) {
+	results := make(map[Key]string, len(pairs))
+	for _, p := range pairs {
+		parts := strings.Split(p, "=")
+		if len(parts) != 2 {
+			return nil, errors.Errorf("%s is not a valid key=value format", p)
+		}
+
+		k, v := Key(parts[0]), parts[1]
+		if _, ok := results[k]; ok {
+			return nil, errors.Errorf("tag with key %s specified more than once", k)
+		}
+
+		if IsReservedKey(k) {
+			glog.Warningf("%s is an Akita-reserved key. Its value may be overwritten internally", k)
+		}
+
+		results[k] = v
+	}
+	return results, nil
+}


### PR DESCRIPTION
Introduced a `tags` package that acts as a central repository for all our tags.