### PR TITLE
Add field-path element for representing a variant of a `OneOf`

### DIFF
--- a/visitors/http_rest/field_path.go
+++ b/visitors/http_rest/field_path.go
@@ -16,6 +16,7 @@ type fieldPathElementKind int
 const (
 	fieldNameKind fieldPathElementKind = iota
 	arrayElementKind
+	oneOfVariantKind
 )
 
 type abstractFieldPathElement struct {
@@ -28,6 +29,10 @@ func (elt *abstractFieldPathElement) IsFieldName() bool {
 
 func (elt *abstractFieldPathElement) IsArrayElement() bool {
 	return elt.kind == arrayElementKind
+}
+
+func (elt *abstractFieldPathElement) IsOneOfVariant() bool {
+	return elt.kind == oneOfVariantKind
 }
 
 // Identifies a field of an object.
@@ -72,4 +77,31 @@ func NewArrayElement(index int) *ArrayElement {
 
 func (ae *ArrayElement) String() string {
 	return fmt.Sprintf("[%d]", ae.Index)
+}
+
+// Identifies a branch of a variant ("one of").
+type OneOfVariant struct {
+	abstractFieldPathElement
+
+	// Identifies the variant being represented.
+	Index int
+
+	// The number of possible variants.
+	NumVariants int
+}
+
+var _ FieldPathElement = (*OneOfVariant)(nil)
+
+func NewOneOfVariant(index int, numVariants int) *OneOfVariant {
+	return &OneOfVariant{
+		abstractFieldPathElement: abstractFieldPathElement{
+			kind: oneOfVariantKind,
+		},
+		Index:       index,
+		NumVariants: numVariants,
+	}
+}
+
+func (oov *OneOfVariant) String() string {
+	return fmt.Sprintf("(format %d of %d)", oov.Index, oov.NumVariants)
 }


### PR DESCRIPTION
Previously, a one-of variant was represented by a `FieldName` named after the variant's hash. This is now replaced with a `OneOfVariant` that encodes how many variants there are, implicitly enumerates the variants, and identifies which variant is on the field path.