### PR TITLE
Fix field path for one-of

### DIFF
--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -515,7 +515,6 @@ func extendContext(cin Context, node interface{}) {
 			astPath := ctx.GetPath()
 			if !astPath.IsEmpty() {
 				astPathEdge := astPath.GetLast().OutEdge
-				astParent := astPath.GetLast().AncestorNode
 
 				// Update the field path.
 				switch edge := astPathEdge.(type) {
@@ -526,21 +525,26 @@ func extendContext(cin Context, node interface{}) {
 				case *MapValueEdge:
 					name := fmt.Sprint(edge.MapKey)
 
-					switch astParent := astParent.(type) {
-					case *pb.OneOf:
+					var astGrandparent interface{} = nil
+					if len(astPath) >= 2 {
+						astGrandparent = astPath.GetNthLast(2).AncestorNode
+					}
+
+					switch astGrandparent := astGrandparent.(type) {
+					case pb.OneOf:
 						// Visiting a child of a OneOf. The name will be a meaningless hash
 						// of the Data being visited. Instead, use a OneOfVariant to
 						// represent the field path. To find the index of the OneOfVariant,
 						// sort the variants by their hash and take the 1-based index in
 						// the resulting array.
-						oneOf := astParent
+						oneOf := astGrandparent
 						numOptions := len(oneOf.Options)
 						variantHashes := []string{}
 						for hash := range oneOf.Options {
 							variantHashes = append(variantHashes, hash)
 						}
 						sort.Strings(variantHashes)
-						index := sort.SearchStrings(variantHashes, name)
+						index := sort.SearchStrings(variantHashes, name) + 1
 
 						ctx.appendFieldPath(NewOneOfVariant(index, numOptions))
 

--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -526,8 +526,8 @@ func extendContext(cin Context, node interface{}) {
 					name := fmt.Sprint(edge.MapKey)
 
 					var astGrandparent interface{} = nil
-					if len(astPath) >= 2 {
-						astGrandparent = astPath.GetNthLast(2).AncestorNode
+					if secondLastElt := astPath.GetNthLast(2); secondLastElt != nil {
+						astGrandparent = secondLastElt.AncestorNode
 					}
 
 					switch astGrandparent := astGrandparent.(type) {

--- a/visitors/visitor.go
+++ b/visitors/visitor.go
@@ -47,9 +47,14 @@ func (c ContextPath) GetLast() ContextPathElement {
 	return c[len(c)-1]
 }
 
-// Returns the `n`-th last element in the path.
-func (c ContextPath) GetNthLast(n int) ContextPathElement {
-	return c[len(c)-n]
+// Returns the `n`-th last element in the path, or nil if there is no such
+// element.
+func (c ContextPath) GetNthLast(n int) *ContextPathElement {
+	numElts := len(c)
+	if 1 <= n && n <= numElts {
+		return &c[numElts-n]
+	}
+	return nil
 }
 
 // Represents an ancestor node and an outgoing edge from that node.

--- a/visitors/visitor.go
+++ b/visitors/visitor.go
@@ -47,6 +47,11 @@ func (c ContextPath) GetLast() ContextPathElement {
 	return c[len(c)-1]
 }
 
+// Returns the `n`-th last element in the path.
+func (c ContextPath) GetNthLast(n int) ContextPathElement {
+	return c[len(c)-n]
+}
+
 // Represents an ancestor node and an outgoing edge from that node.
 type ContextPathElement struct {
 	AncestorNode interface{}


### PR DESCRIPTION
Need to look to grandparent to find the `OneOf`. The parent is just a `map[string]*Data`.

Actually count variants starting from 1.