### PR TITLE
Fix typo in a backward-compatible way.

### DIFF
--- a/test/proto_util.go
+++ b/test/proto_util.go
@@ -78,8 +78,10 @@ func LoadMethodsFromFileOrDie(path string) []*pb.Method {
 	return spec.Methods
 }
 
-func LoadWitnessFromFileOrDile(path string) *pb.Witness {
+func LoadWitnessFromFileOrDie(path string) *pb.Witness {
 	w := &pb.Witness{}
 	loadProtoFromFileOrDie(path, w)
 	return w
 }
+
+var LoadWitnessFromFileOrDile = LoadWitnessFromFileOrDie


### PR DESCRIPTION
I discovered I could not fix this in superstar alone, alas.