### PR TITLE
Reduce amount of hashing for methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/akitasoftware/akita-ir v0.0.0-20210211235551-a548c32e7fbe
-	github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba
+	github.com/akitasoftware/objecthash-proto v0.0.0-20210728012103-5dba715f04e7
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	// Golang protobuf APIv1, needed to compatibility with objecthash-proto. See

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/akitasoftware/akita-ir v0.0.0-20210211235551-a548c32e7fbe
-	github.com/akitasoftware/objecthash-proto v0.0.0-20210728012103-5dba715f04e7
+	github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	// Golang protobuf APIv1, needed to compatibility with objecthash-proto. See

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,11 @@ github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkj
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba h1:sAv1pLJk8VU9q8CddBocaftsZnb2ppbBEQSN6H5O3kg=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba/go.mod h1:otNn0Cq1YGR1daOez6qwaCaF9tzRk1YkIsxF+6faKNE=
+github.com/akitasoftware/objecthash-proto v0.0.0-20210728012103-5dba715f04e7 h1:kipCYMDo+dYkUgA5gx8a1XEO70/McEuZtPBSUPugHVE=
+github.com/akitasoftware/objecthash-proto v0.0.0-20210728012103-5dba715f04e7/go.mod h1:5/6U7s9Kj5GXRZBiQejikd06mPYYWC+C1RoO8ehvifs=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1/go.mod h1:jvdWlw8vowVGnZqSDC7yhPd7AifQeQbRDkZcQXV2nRg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkj
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba h1:sAv1pLJk8VU9q8CddBocaftsZnb2ppbBEQSN6H5O3kg=
 github.com/akitasoftware/objecthash-proto v0.0.0-20200508002052-e5b6b45fd2ba/go.mod h1:otNn0Cq1YGR1daOez6qwaCaF9tzRk1YkIsxF+6faKNE=
-github.com/akitasoftware/objecthash-proto v0.0.0-20210728012103-5dba715f04e7 h1:kipCYMDo+dYkUgA5gx8a1XEO70/McEuZtPBSUPugHVE=
-github.com/akitasoftware/objecthash-proto v0.0.0-20210728012103-5dba715f04e7/go.mod h1:5/6U7s9Kj5GXRZBiQejikd06mPYYWC+C1RoO8ehvifs=
+github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09 h1:jFDx6V2CBAdfbpPOduXgj3E+Se2Unadvu0pfDMZ1aQI=
+github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09/go.mod h1:5/6U7s9Kj5GXRZBiQejikd06mPYYWC+C1RoO8ehvifs=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1/go.mod h1:jvdWlw8vowVGnZqSDC7yhPd7AifQeQbRDkZcQXV2nRg=

--- a/pbhash/pbhash_test.go
+++ b/pbhash/pbhash_test.go
@@ -1,0 +1,50 @@
+package pbhash
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/akitasoftware/akita-libs/test"
+	protohash "github.com/akitasoftware/objecthash-proto"
+)
+
+func TestHash(t *testing.T) {
+	// Should get the same result if we remove hashmap assumptions.
+	slowOptions := []protohash.Option{}
+	for _, opt := range options {
+		if _, isAssumeHashMap := opt.(protohash.IsAssumeHashMap); !isAssumeHashMap {
+			slowOptions = append(slowOptions, opt)
+		}
+	}
+
+	slowHasher := protohash.NewHasher(slowOptions...)
+
+	spec := test.LoadAPISpecFromFileOrDie("../spec_util/testdata/generalize_witnesses/spec.pb.txt")
+
+	// Sanity-check the test case. The args and responses should be mapped by
+	// their hashes.
+	for _, m := range spec.GetMethods() {
+		for k, v := range m.Args {
+			k2, err := hashProto(v, slowHasher)
+			assert.Nil(t, err, "Error hashing arg")
+			assert.Equal(t, k, k2)
+		}
+		for k, v := range m.Responses {
+			k2, err := hashProto(v, slowHasher)
+			assert.Nil(t, err, "Error hashing response")
+			assert.Equal(t, k, k2)
+		}
+	}
+
+	// Check the overall hash of the entire method.
+	{
+		h1, err := HashProto(spec)
+		assert.Nil(t, err, "Error hashing spec")
+
+		h2, err := hashProto(spec, slowHasher)
+		assert.Nil(t, err, "Error hashing spec with slow hasher")
+
+		assert.Equal(t, h2, h1)
+	}
+}

--- a/spec_util/testdata/generalize_witnesses/spec.pb.txt
+++ b/spec_util/testdata/generalize_witnesses/spec.pb.txt
@@ -63,7 +63,7 @@ methods: <
     >
   >
   args: <
-    key: "y0HmMXfg67c="
+    key: "NG5nItAmli0="
     value: <
       primitive: <
         int64_value: <
@@ -1474,7 +1474,7 @@ methods: <
     >
   >
   args: <
-    key: "jX1cqTk1FwI="
+    key: "Sajk40aPGIE="
     value: <
       oneof: <
         options: <
@@ -1541,7 +1541,7 @@ methods: <
     >
   >
   responses: <
-    key: "8hxKYc8Y3xY="
+    key: "5iN-vStDGBI="
     value: <
       primitive: <
         int64_value: <
@@ -1558,7 +1558,7 @@ methods: <
     >
   >
   responses: <
-    key: "9kxgQS-ZhWw="
+    key: "KLFXCSsXykc="
     value: <
       primitive: <
         int64_value: <
@@ -3663,7 +3663,7 @@ methods: <
     >
   >
   responses: <
-    key: "XmREjBpvvEY="
+    key: "ch5Sx0Qndi0="
     value: <
       primitive: <
         int64_value: <
@@ -3697,7 +3697,7 @@ methods: <
     >
   >
   responses: <
-    key: "rV7hGHatcSA="
+    key: "MBF3u9y90gs="
     value: <
       primitive: <
         int64_value: <


### PR DESCRIPTION
If IR trees are consistent, then the requests and responses for each `Method` instance should be mapped by their hashes. When hashing a `Method`, use these hash values instead of recomputing them.