### PR TITLE
Reduce memory usage of spec visitor

### DIFF
--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -749,7 +749,7 @@ func leave(cin Context, visitor interface{}, node interface{}, cont Cont) Cont {
 
 // Visits m with v.
 func Apply(v SpecVisitor, m interface{}) Cont {
-	c := new(specVisitorContext)
+	c := NewPreallocatedVisitorContext()
 	vis := NewVisitorManager(c, v, enter, visitChildren, leave, extendContext)
 	return go_ast.Apply(vis, m)
 }

--- a/visitors/http_rest/spec_visitor_context.go
+++ b/visitors/http_rest/spec_visitor_context.go
@@ -312,3 +312,199 @@ func (c *specVisitorContext) setHttpAuthType(at pb.HTTPAuth_HTTPAuthType) {
 func (c *specVisitorContext) setTopLevelDataIndex(i int) {
 	c.topDataIndex = i
 }
+
+// Preallocate a stack of specVisitorContexts
+type contextStack struct {
+	Stack  []specVisitorContext
+	Latest int
+}
+
+func NewPreallocatedVisitorContext() SpecVisitorContext {
+	cs := &contextStack{
+		Stack:  make([]specVisitorContext, 10),
+		Latest: 0,
+	}
+	return stackVisitorContext{
+		Preallocated: cs,
+		Position:     0,
+	}
+}
+
+type stackVisitorContext struct {
+	Preallocated *contextStack
+	Position     int
+}
+
+// Allocate a new context from ths stack.
+// No explicit Pop(), but we can track whether an old context
+// is re-used erroneously.
+func (s *contextStack) Push(parent int) int {
+	if parent > s.Latest {
+		panic("push context from too deep in stack")
+	}
+	next := parent + 1
+	if next == len(s.Stack) {
+		s.Stack = append(s.Stack, specVisitorContext{})
+	} else if next > len(s.Stack) {
+		panic("push increases size by more than 1")
+	}
+	s.Latest = next
+	return next
+}
+
+// This pointer is only valid until the slice is resized, so it should be used
+// and then immediately discarded.
+func (c stackVisitorContext) Delegate() *specVisitorContext {
+	return &c.Preallocated.Stack[c.Position]
+}
+
+func (c stackVisitorContext) EnterStruct(structNode interface{}, fieldName string) visitors.Context {
+	return c.appendPath(visitors.ContextPathElement{
+		AncestorNode: structNode,
+		OutEdge:      visitors.NewStructFieldEdge(fieldName),
+	})
+}
+
+func (c stackVisitorContext) EnterArray(arrayNode interface{}, elementIndex int) visitors.Context {
+	return c.appendPath(visitors.ContextPathElement{
+		AncestorNode: arrayNode,
+		OutEdge:      visitors.NewArrayElementEdge(elementIndex),
+	})
+}
+
+func (c stackVisitorContext) EnterMapValue(mapNode, mapKey interface{}) visitors.Context {
+	return c.appendPath(visitors.ContextPathElement{
+		AncestorNode: mapNode,
+		OutEdge:      visitors.NewMapValueEdge(mapKey),
+	})
+}
+
+func (c stackVisitorContext) appendPath(e visitors.ContextPathElement) stackVisitorContext {
+	// Allocate the next-deepest element on the stack
+	newPosition := c.Preallocated.Push(c.Position)
+	newContext := stackVisitorContext{
+		Preallocated: c.Preallocated,
+		Position:     newPosition,
+	}
+
+	// Copy ourselves
+	d := newContext.Delegate()
+	*d = *(c.Delegate())
+
+	// Extend the path
+	d.path = append(d.path, e)
+	d.outer = d
+	return newContext
+}
+
+func (c stackVisitorContext) GetPath() visitors.ContextPath {
+	return c.Delegate().GetPath()
+}
+
+func (c stackVisitorContext) GetOuter() visitors.Context {
+	return c.Delegate().GetOuter()
+}
+
+func (c stackVisitorContext) appendFieldPath(elt FieldPathElement) {
+	c.Delegate().appendFieldPath(elt)
+}
+
+func (c stackVisitorContext) GetFieldPath() []FieldPathElement {
+	return c.Delegate().GetFieldPath()
+}
+
+func (c stackVisitorContext) appendRestPath(s string) {
+	c.Delegate().appendRestPath(s)
+}
+
+func (c stackVisitorContext) GetRestPath() []string {
+	return c.Delegate().GetRestPath()
+}
+
+func (c stackVisitorContext) GetRestOperation() string {
+	return c.Delegate().GetRestOperation()
+}
+
+func (c stackVisitorContext) setRestOperation(op string) {
+	c.Delegate().setRestOperation(op)
+}
+
+func (c stackVisitorContext) IsArg() bool {
+	return c.Delegate().IsArg()
+}
+
+func (c stackVisitorContext) IsResponse() bool {
+	return c.Delegate().IsResponse()
+}
+
+func (c stackVisitorContext) IsOptional() bool {
+	return c.Delegate().IsOptional()
+}
+
+func (c stackVisitorContext) GetValueType() HttpValueType {
+	return c.Delegate().GetValueType()
+}
+
+func (c stackVisitorContext) GetHttpAuthType() *pb.HTTPAuth_HTTPAuthType {
+	return c.Delegate().GetHttpAuthType()
+}
+
+func (c stackVisitorContext) GetArgPath() []string {
+	return c.Delegate().GetArgPath()
+}
+
+func (c stackVisitorContext) GetResponsePath() []string {
+	return c.Delegate().GetResponsePath()
+}
+
+func (c stackVisitorContext) GetEndpointPath() string {
+	return c.Delegate().GetEndpointPath()
+}
+
+func (c stackVisitorContext) GetResponseCode() *string {
+	return c.Delegate().GetResponseCode()
+}
+
+func (c stackVisitorContext) GetContentType() *string {
+	return c.Delegate().GetContentType()
+}
+
+func (c stackVisitorContext) GetHost() string {
+	return c.Delegate().GetHost()
+}
+
+func (c stackVisitorContext) GetInnermostNode(typ reflect.Type) (interface{}, SpecVisitorContext) {
+	return c.Delegate().GetInnermostNode(typ)
+}
+
+func (c stackVisitorContext) getTopLevelDataPath() []string {
+	return c.Delegate().getTopLevelDataPath()
+}
+
+func (c stackVisitorContext) setIsArg(isArg bool) {
+	c.Delegate().setIsArg(isArg)
+}
+
+func (c stackVisitorContext) setIsOptional() {
+	c.Delegate().setIsOptional()
+}
+
+func (c stackVisitorContext) setValueType(vt HttpValueType) {
+	c.Delegate().setValueType(vt)
+}
+
+func (c stackVisitorContext) setResponseCode(code string) {
+	c.Delegate().setResponseCode(code)
+}
+
+func (c stackVisitorContext) setContentType(contentType string) {
+	c.Delegate().setContentType(contentType)
+}
+
+func (c stackVisitorContext) setHttpAuthType(at pb.HTTPAuth_HTTPAuthType) {
+	c.Delegate().setHttpAuthType(at)
+}
+
+func (c stackVisitorContext) setTopLevelDataIndex(i int) {
+	c.Delegate().setTopLevelDataIndex(i)
+}

--- a/visitors/http_rest/spec_visitor_context.go
+++ b/visitors/http_rest/spec_visitor_context.go
@@ -320,8 +320,10 @@ type contextStack struct {
 }
 
 func NewPreallocatedVisitorContext() SpecVisitorContext {
+	// TODO: can we make this self-tuning? Remember the 90th percentile depth
+	// and preallocate that?
 	cs := &contextStack{
-		Stack:  make([]specVisitorContext, 10),
+		Stack:  make([]specVisitorContext, 10, 50),
 		Latest: 0,
 	}
 	return stackVisitorContext{
@@ -388,6 +390,8 @@ func (c stackVisitorContext) appendPath(e visitors.ContextPathElement) stackVisi
 	}
 
 	// Copy ourselves
+	// TODO: can we do this lazily as well? for example, keep two pointers, one for the
+	// values modified below, and another for the mutable values?
 	d := newContext.Delegate()
 	*d = *(c.Delegate())
 


### PR DESCRIPTION
Preallocate all the context objects in a stack and re-use them.
Create ContextPath on demand.

Example alloc_space profile before:
```
      flat  flat%   sum%        cum   cum%
   30.99GB 37.84% 37.84%    30.99GB 37.84%  github.com/akitasoftware/akita-libs/visitors/http_rest.(*specVisitorContext).appendPath
    4.55GB  5.56% 43.40%     4.55GB  5.56%  reflect.packEface
    4.49GB  5.48% 48.88%     4.49GB  5.48%  bytes.makeSlice
    3.89GB  4.76% 53.64%     3.90GB  4.76%  time.parse
    3.61GB  4.41% 58.05%     3.61GB  4.41%  encoding/json.(*Decoder).refill
    3.19GB  3.90% 61.94%     3.20GB  3.91%  github.com/google/gopacket/pcap.(*Handle).ReadPacketData
    3.12GB  3.81% 65.75%     7.49GB  9.15%  github.com/google/gopacket.(*PacketSource).NextPacket
    2.35GB  2.87% 68.62%     7.86GB  9.60%  github.com/akitasoftware/objecthash-proto.(*objectHasher).hashStruct
    1.75GB  2.14% 70.76%     1.75GB  2.14%  github.com/OneOfOne/xxhash.NewS64 (inline)
    1.57GB  1.92% 72.68%     3.20GB  3.91%  github.com/golang/protobuf/proto.Marshal
```

Example alloc_space profile after:
```
      flat  flat%   sum%        cum   cum%
    3.34GB  8.71%  8.71%     3.34GB  8.71%  reflect.packEface
    2.76GB  7.21% 15.92%     2.76GB  7.21%  time.parse
    2.27GB  5.93% 21.85%     2.27GB  5.93%  bytes.makeSlice
    2.03GB  5.29% 27.14%     4.09GB 10.67%  github.com/akitasoftware/akita-libs/visitors/http_rest.stackVisitorContext.EnterStruct
    1.85GB  4.84% 31.98%     1.85GB  4.84%  encoding/json.(*Decoder).refill
    1.72GB  4.48% 36.46%     5.57GB 14.54%  github.com/akitasoftware/objecthash-proto.(*objectHasher).hashStruct
    1.65GB  4.31% 40.77%     1.66GB  4.33%  github.com/google/gopacket/pcap.(*Handle).ReadPacketData
    1.59GB  4.15% 44.91%     4.18GB 10.91%  github.com/google/gopacket.(*PacketSource).NextPacket
    1.54GB  4.01% 48.93%     1.54GB  4.01%  github.com/akitasoftware/akita-libs/visitors/http_rest.stackVisitorContext.appendPath
    1.31GB  3.42% 52.35%     1.31GB  3.42%  github.com/OneOfOne/xxhash.NewS64 (inline)
```