### PR TITLE
Extend path parameter patterns with wildcards

### DIFF
--- a/path_pattern/components.go
+++ b/path_pattern/components.go
@@ -28,6 +28,18 @@ func (v Var) String() string {
 	return "{" + string(v) + "}"
 }
 
+// A component that matches any path argument, either a concrete value or a
+// parameter.
+type Wildcard struct{}
+
+func (Wildcard) Match(c string) bool {
+	return true
+}
+
+func (Wildcard) String() string {
+	return "*"
+}
+
 // A component that should retain the original value verbatim, otherwise behaves
 // like a wildcard.
 type Placeholder struct{}

--- a/path_pattern/pattern.go
+++ b/path_pattern/pattern.go
@@ -46,7 +46,9 @@ func Parse(v string) Pattern {
 	result := make(Pattern, 0, len(parts))
 
 	for _, p := range parts {
-		if p == "^" {
+		if p == "*" {
+			result = append(result, Wildcard{})
+		} else if p == "^" {
 			result = append(result, Placeholder{})
 		} else if strings.HasPrefix(p, "{") && strings.HasSuffix(p, "}") {
 			result = append(result, Var(p[1:len(p)-1]))

--- a/path_pattern/pattern_test.go
+++ b/path_pattern/pattern_test.go
@@ -39,6 +39,15 @@ func TestParseAndString(t *testing.T) {
 				Val("foobar"),
 			},
 		},
+		{
+			input: "/v1/*/foobar",
+			expected: Pattern{
+				Val(""),
+				Val("v1"),
+				Wildcard{},
+				Val("foobar"),
+			},
+		},
 	}
 
 	for _, c := range testCases {
@@ -72,6 +81,16 @@ func TestMatch(t *testing.T) {
 		{
 			pattern:     "/v1/{my_arg_name}",
 			target:      "/v1/{my_old_arg_name}",
+			expectMatch: true,
+		},
+		{
+			pattern:     "/v1/*/{my_arg_name}",
+			target:      "/v1/foo/bar",
+			expectMatch: true,
+		},
+		{
+			pattern:     "/v1/*/{my_arg_name}",
+			target:      "/v1/{foo_param}/bar",
 			expectMatch: true,
 		},
 		{


### PR DESCRIPTION
This adds a wildcard component (`*`) to path parameter patterns,
which matches any content within a path position.

For example, the pattern `/*`
 - matches `/foo`
 - matches `/{param}`
 - does not match `/foo/bar`
 - does not match `/{param}/bar`

This is functionally similar to the Placeholder (`^`) component but semantically different.  Placeholders indicate path parameter locations that should not be generalized into a path parameter, whereas Wildcard components do not have any special meaning beyond matching anything.