### PR TITLE
Error on out-of-range response codes

### DIFF
--- a/akinet/har.go
+++ b/akinet/har.go
@@ -81,6 +81,9 @@ func (r *HTTPRequest) FromHAR(h *har.Request) error {
 }
 
 func (r *HTTPResponse) FromHAR(h *har.Response) error {
+	if h.Status < 200 || h.Status > 599 {
+		return errors.Errorf("status code %v out of range", h.Status)
+	}
 	r.StatusCode = h.Status
 
 	// HTTP version


### PR DESCRIPTION
A user has reported seeing 0's in the HAR file; this will filter out those responses.