### PR TITLE
If no method match is found, take any path match.

### DIFF
--- a/spec_util/matcher.go
+++ b/spec_util/matcher.go
@@ -15,7 +15,7 @@ type methodRegexp struct {
 	Host              string         // HTTP host
 	Template          string         // original method template
 	RE                *regexp.Regexp // template converted to regexp on path
-	VariablePositions []int          // positions of path variables in templates
+	VariablePositions []int          // positions of path variables in templates, in sorted order
 }
 
 func (r methodRegexp) LessThan(other methodRegexp) bool {
@@ -111,8 +111,8 @@ var (
 // to a regular expression that matches the entire path like
 // ^v1/api/get/user/([^/]+)/([^/]+)$
 //
-// Return the position of each argument within the original template,
-// counting variables as length 1.
+// Return the position of each argument within the original template, in sorted order,
+// counting all variables as length 1.
 func templateToRegexp(pathTemplate string) (*regexp.Regexp, []int, error) {
 	// If there are special characters, then the easiest way to escape them is
 	// to break the string up by arguments, and escape everything in between.

--- a/spec_util/matcher.go
+++ b/spec_util/matcher.go
@@ -2,6 +2,7 @@ package spec_util
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -10,15 +11,39 @@ import (
 )
 
 type methodRegexp struct {
-	Operation string         // HTTP operation
-	Host      string         // HTTP host
-	Template  string         // original method template
-	RE        *regexp.Regexp // template converted to regexp on path
+	Operation         string         // HTTP operation
+	Host              string         // HTTP host
+	Template          string         // original method template
+	RE                *regexp.Regexp // template converted to regexp on path
+	VariablePositions []int          // positions of path variables in templates
+}
+
+func (r methodRegexp) LessThan(other methodRegexp) bool {
+	for i, p := range r.VariablePositions {
+		// Other template has more specific path if it has fewer
+		// variables, or the variable in it comes later.
+		if i >= len(other.VariablePositions) {
+			return false
+		}
+		if p < other.VariablePositions[i] {
+			return false
+		}
+		if p > other.VariablePositions[i] {
+			return true
+		}
+	}
+	// Fall back to string comparison
+	if r.Template < other.Template {
+		return true
+	}
+	return false
 }
 
 // MethodMatcher is currently a list of regular expressions to try in order;
 // in the future it could be a tree lookup structure (for efficiency and
 // to more easily accommodate longest-prefix matching.)
+//
+// During creation, ensure that /abc/def is sorted before /abc/{var1} so that the former is preferred.
 type MethodMatcher struct {
 	methods []methodRegexp
 }
@@ -39,11 +64,23 @@ func (m *MethodMatcher) Lookup(operation string, path string) (template string) 
 
 // Lookup returns either a matching template, or the original path if no match is found.
 // This version matches on host as well.
+// If there is no exact match on (operation, host,string) accept a partial match on (host,string) instead.
+// This handles things calls like OPTION that we do not include in our API model, which currently does
+// path parameter inference without considering operations to be distinct.
 func (m *MethodMatcher) LookupWithHost(operation string, host string, path string) (template string) {
 	for _, candidate := range m.methods {
 		if candidate.Operation != operation {
 			continue
 		}
+		if candidate.Host != host {
+			continue
+		}
+		if candidate.RE.MatchString(path) {
+			return candidate.Template
+		}
+	}
+	// If we failed, try again without Operation filter
+	for _, candidate := range m.methods {
 		if candidate.Host != host {
 			continue
 		}
@@ -73,7 +110,10 @@ var (
 // v1/api/get/user/{arg1}/{arg2}
 // to a regular expression that matches the entire path like
 // ^v1/api/get/user/([^/]+)/([^/]+)$
-func templateToRegexp(pathTemplate string) (*regexp.Regexp, error) {
+//
+// Return the position of each argument within the original template,
+// counting variables as length 1.
+func templateToRegexp(pathTemplate string) (*regexp.Regexp, []int, error) {
 	// If there are special characters, then the easiest way to escape them is
 	// to break the string up by arguments, and escape everything in between.
 	literals := uriArgumentRegexp.Split(pathTemplate, -1)
@@ -83,21 +123,28 @@ func templateToRegexp(pathTemplate string) (*regexp.Regexp, error) {
 	// the end.
 	var buf strings.Builder
 	buf.WriteString("^")
+	positions := make([]int, 0, len(literals)-1)
 	first := true
+	currentPosition := 0
+
 	for _, l := range literals {
 		if first {
+			// No variable before the first literal
 			first = false
 		} else {
 			buf.WriteString(uriPathCharacters)
+			positions = append(positions, currentPosition)
+			currentPosition += 1
 		}
 		buf.WriteString(regexp.QuoteMeta(l))
+		currentPosition += len(l)
 	}
 	buf.WriteString("$")
 	re, err := regexp.Compile(buf.String())
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not convert template %q to regexp", pathTemplate)
+		return nil, nil, errors.Wrapf(err, "could not convert template %q to regexp", pathTemplate)
 	}
-	return re, nil
+	return re, positions, nil
 
 }
 
@@ -114,16 +161,23 @@ func NewMethodMatcher(spec *pb.APISpec) (*MethodMatcher, error) {
 		if httpMeta == nil {
 			continue // just ignore non-http methods
 		}
-		re, err := templateToRegexp(httpMeta.PathTemplate)
+		re, positions, err := templateToRegexp(httpMeta.PathTemplate)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not extract paths from spec")
 		}
 		mm.methods = append(mm.methods, methodRegexp{
-			Operation: httpMeta.Method,
-			Host:      httpMeta.Host,
-			Template:  httpMeta.PathTemplate,
-			RE:        re,
+			Operation:         httpMeta.Method,
+			Host:              httpMeta.Host,
+			Template:          httpMeta.PathTemplate,
+			RE:                re,
+			VariablePositions: positions,
 		})
 	}
+
+	// Order by most-specific path first
+	sort.Slice(mm.methods, func(i, j int) bool {
+		return mm.methods[i].LessThan(mm.methods[j])
+	})
+
 	return mm, nil
 }


### PR DESCRIPTION
Also ensures paths are checked from least to most specific.

This was motivated by our timeline having a lot of OPTION calls that were not getting templatized.  (Unfortunately, at the time OPTION is called we don't know whether the next call is going to be PUT, POST, GET, or not arrive at all.)

Cole says that we don't consider method when performing path variable inference anyway?
