### PR TITLE
Add service graph API types.

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -396,3 +396,23 @@ type TimelineResponse struct {
 	// If incomplete due to limit, the first unreported start time
 	NextStartTime *time.Time `json:"next_start_time,omitempty"`
 }
+
+type GraphEdge struct {
+	// Describe the source and destination vertices by the attributes
+	// they share in common: either just Host for a service-level vertex,
+	// or Host + Method + PathTemplate for a end-point level vertex, although
+	// we could imagine other possibilities.
+	SourceAttributes EndpointGroupAttributes `json:"source_attrs"`
+	TargetAttributes EndpointGroupAttributes `json:"target_attrs"`
+
+	// Aggregate values attached to the edge, e.g., "count"
+	Values map[TimelineValue]float32 `json:"values"`
+}
+
+type GraphResponse struct {
+	// Edges of the graph
+	Edges []GraphEdge `json:"edges"`
+
+	// TODO: vertex list? vertex or edge count?
+	// TODO: pagination
+}


### PR DESCRIPTION
Graph is represented by a list of edges.

Each edge identifies the source and destination vertex using the type we've already defined for examples and timeline view.

```
{
  "edges": [
    {
      "source_attrs": {
        "host": "54.241.154.237:32677"
      },
      "target_attrs": {
        "host": "ts-contacts-service:12347"
      },
      "values": {
        "count": 3
      }
    },
    ....
    {
      "source_attrs": {},
      "target_attrs": {
        "host": "ts-user-service:12342"
      },
      "values": {
        "count": 3
      }
    },
}
```

The "source" may be empty, as illustrated above, if the source is unknown.
