### PR TITLE
Replace pbhash by ir_hash in spec_util functions

### DIFF
--- a/spec_util/constructors.go
+++ b/spec_util/constructors.go
@@ -2,25 +2,20 @@ package spec_util
 
 import (
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
-	"github.com/pkg/errors"
-
-	"github.com/akitasoftware/akita-libs/pbhash"
+	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
 )
 
-func OneOf (data []*pb.Data, isConflict bool) (*pb.OneOf, error) {
+func OneOf(data []*pb.Data, isConflict bool) (*pb.OneOf, error) {
 	if len(data) == 0 {
 		return &pb.OneOf{PotentialConflict: isConflict}, nil
 	}
 	options := make(map[string]*pb.Data, len(data))
 	for _, option := range data {
-		hash, err := pbhash.HashProto(option)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to hash data: %v", option)
-		}
+		hash := ir_hash.HashDataToString(option)
 		options[hash] = option
 	}
 	return &pb.OneOf{
-		Options:              options,
-		PotentialConflict:    isConflict,
+		Options:           options,
+		PotentialConflict: isConflict,
 	}, nil
 }

--- a/spec_util/generalize_witnesses.go
+++ b/spec_util/generalize_witnesses.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
-	"github.com/akitasoftware/akita-libs/pbhash"
+	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
 )
 
 func GetPathRegexps(spec *pb.APISpec) map[*regexp.Regexp]string {
@@ -77,10 +77,7 @@ func GeneralizeWitness(pathMatchers map[*regexp.Regexp]string, witnessIn *pb.Wit
 				Meta:     argMeta,
 				Nullable: false,
 			}
-			hash, err := pbhash.HashProto(argData)
-			if err != nil {
-				return nil, err
-			}
+			hash := ir_hash.HashDataToString(argData)
 			witness.GetMethod().Args[hash] = argData
 		}
 
@@ -118,12 +115,11 @@ func getPathRegexps(paths []string) map[*regexp.Regexp]string {
 	parameterMatcher := regexp.MustCompile("{(.*?)}")
 	for _, path := range paths {
 		// Remove trailing slash, if any
-		if len(path) > 0 && path[len(path) - 1] == '/' {
-			path = path[0:len(path) - 1]
+		if len(path) > 0 && path[len(path)-1] == '/' {
+			path = path[0 : len(path)-1]
 		}
 		pathRegexp := regexp.MustCompile("^" + parameterMatcher.ReplaceAllString(path, "(?P<$1>[^{/}]*)") + "$")
 		rv[pathRegexp] = path
 	}
 	return rv
 }
-

--- a/spec_util/hash_keys.go
+++ b/spec_util/hash_keys.go
@@ -4,7 +4,7 @@ import (
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/pkg/errors"
 
-	"github.com/akitasoftware/akita-libs/pbhash"
+	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
 	. "github.com/akitasoftware/akita-libs/visitors"
 	"github.com/akitasoftware/akita-libs/visitors/http_rest"
 )
@@ -31,11 +31,7 @@ func (vis *hashOneOfVisitor) LeaveData(self interface{}, c http_rest.SpecVisitor
 
 	for _, k := range keys {
 		v := options[k]
-		h, err := pbhash.HashProto(v)
-		if err != nil {
-			vis.err = err
-			return Abort
-		}
+		h := ir_hash.HashDataToString(v)
 		if k != h {
 			delete(options, k)
 			options[h] = v
@@ -68,10 +64,7 @@ func RewriteHashKeys(spec *pb.APISpec) error {
 			}
 			for _, k := range keys {
 				arg := m[k]
-				h, err := pbhash.HashProto(arg)
-				if err != nil {
-					return errors.Wrap(err, "failed to compute hash of method argument")
-				}
+				h := ir_hash.HashDataToString(arg)
 				if h != k {
 					delete(m, k)
 					m[h] = arg

--- a/spec_util/ir_hash/wrappers.go
+++ b/spec_util/ir_hash/wrappers.go
@@ -14,4 +14,8 @@ func HashDataToString(d *pb.Data) string {
 	return base64.URLEncoding.EncodeToString(HashData(d))
 }
 
+func HashDataMetaToString(d *pb.DataMeta) string {
+	return base64.URLEncoding.EncodeToString(HashDataMeta(d))
+}
+
 // TODO: take any proto.Message or interface{} and hash it?


### PR DESCRIPTION
Verified that the only remaining uses in akita-lib are for testing ir_hash itself.

Semgrep rule in YAML format
```yaml
rules:
- id: pbhash usage in superstar
  pattern: pbhash.HashProto($X)
  message: Use of pbhash is deprecated
  languages: [go]
  severity: WARNING
```
