### PR TITLE
Change DefaultSpecVisitor to avoid reflection.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e
 	github.com/akitasoftware/objecthash-proto v0.0.0-20211020004800-9990a7ea5dc0
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
-	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.0
 	github.com/google/go-cmp v0.5.6
@@ -17,7 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
-	google.golang.org/protobuf v1.27.1 // indirect
+	google.golang.org/protobuf v1.27.1
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1,17 +1,11 @@
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/akitasoftware/akita-ir v0.0.0-20211019194545-68f0981c005a h1:RoaxWSGcofsQNr3xw63yvRrZhVvvqu0h0FdgCWP2YMU=
-github.com/akitasoftware/akita-ir v0.0.0-20211019194545-68f0981c005a/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e h1:zBjVbWV3ZHEv4N+TXfitP10gdAUdAWIECsVH0WhHAms=
 github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b/go.mod h1:wteInquxIdgWpGJEJmJEMJVtqM2i2vFZJ4W7B8G9ex8=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de/go.mod h1:qDTWoRR9LvzAsPM1JYaThR7tyE63cEy3XPkox/4pP1A=
-github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09 h1:jFDx6V2CBAdfbpPOduXgj3E+Se2Unadvu0pfDMZ1aQI=
-github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09/go.mod h1:5/6U7s9Kj5GXRZBiQejikd06mPYYWC+C1RoO8ehvifs=
-github.com/akitasoftware/objecthash-proto v0.0.0-20211020003201-08b3014c5610 h1:lkHSIAhYNv0gHY3Q+tt0kMrtu247QdyC29bNRrcLtZ0=
-github.com/akitasoftware/objecthash-proto v0.0.0-20211020003201-08b3014c5610/go.mod h1:otNn0Cq1YGR1daOez6qwaCaF9tzRk1YkIsxF+6faKNE=
 github.com/akitasoftware/objecthash-proto v0.0.0-20211020004800-9990a7ea5dc0 h1:kFSvcyPgHPECo8gl6RrZFzGJJLL2TM3lmGxvymF5e9s=
 github.com/akitasoftware/objecthash-proto v0.0.0-20211020004800-9990a7ea5dc0/go.mod h1:5/6U7s9Kj5GXRZBiQejikd06mPYYWC+C1RoO8ehvifs=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
@@ -26,7 +20,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -137,7 +137,8 @@ func (*DefaultSpecVisitorImpl) EnterAPISpec(self interface{}, c SpecVisitorConte
 }
 
 func (*DefaultSpecVisitorImpl) VisitAPISpecChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, spec *pb.APISpec) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, spec)
+	// Methods is a []*Method, but Tags is just map[string]string
+	return visitStructMembers(c, vm, spec, "Methods", spec.Methods)
 }
 
 func (*DefaultSpecVisitorImpl) LeaveAPISpec(self interface{}, c SpecVisitorContext, spec *pb.APISpec, cont Cont) Cont {
@@ -151,7 +152,15 @@ func (*DefaultSpecVisitorImpl) EnterMethod(self interface{}, c SpecVisitorContex
 }
 
 func (*DefaultSpecVisitorImpl) VisitMethodChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.Method) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	if m != nil {
+		return visitStructMembers(c, vm, m,
+			"Id", m.Id,
+			"Args", m.Args,
+			"Responses", m.Responses,
+			"Meta", m.Meta,
+		)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveMethod(self interface{}, c SpecVisitorContext, m *pb.Method, cont Cont) Cont {
@@ -165,7 +174,10 @@ func (*DefaultSpecVisitorImpl) EnterMethodMeta(self interface{}, c SpecVisitorCo
 }
 
 func (*DefaultSpecVisitorImpl) VisitMethodMetaChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.MethodMeta) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	if m != nil {
+		return visitStructMembers(c, vm, m, "Meta", m.Meta)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveMethodMeta(self interface{}, c SpecVisitorContext, m *pb.MethodMeta, cont Cont) Cont {
@@ -179,7 +191,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPMethodMeta(self interface{}, c SpecVisit
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPMethodMetaChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.HTTPMethodMeta) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPMethodMeta(self interface{}, c SpecVisitorContext, m *pb.HTTPMethodMeta, cont Cont) Cont {
@@ -193,7 +206,14 @@ func (*DefaultSpecVisitorImpl) EnterData(self interface{}, c SpecVisitorContext,
 }
 
 func (*DefaultSpecVisitorImpl) VisitDataChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.Data) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d,
+			"Value", d.Value,
+			"Meta", d.Meta,
+			"ExampleValues", d.ExampleValues,
+		)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveData(self interface{}, c SpecVisitorContext, d *pb.Data, cont Cont) Cont {
@@ -207,7 +227,10 @@ func (*DefaultSpecVisitorImpl) EnterDataMeta(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitDataMetaChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.DataMeta) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d, "Meta", d.Meta)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveDataMeta(self interface{}, c SpecVisitorContext, d *pb.DataMeta, cont Cont) Cont {
@@ -221,7 +244,10 @@ func (*DefaultSpecVisitorImpl) EnterHTTPMeta(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPMetaChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.HTTPMeta) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	if m != nil {
+		return visitStructMembers(c, vm, m, "Location", m.Location)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPMeta(self interface{}, c SpecVisitorContext, m *pb.HTTPMeta, cont Cont) Cont {
@@ -235,7 +261,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPPath(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPPathChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, p *pb.HTTPPath) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, p)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPPath(self interface{}, c SpecVisitorContext, p *pb.HTTPPath, cont Cont) Cont {
@@ -249,7 +276,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPQuery(self interface{}, c SpecVisitorCon
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPQueryChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, q *pb.HTTPQuery) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, q)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPQuery(self interface{}, c SpecVisitorContext, q *pb.HTTPQuery, cont Cont) Cont {
@@ -263,7 +291,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPHeader(self interface{}, c SpecVisitorCo
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPHeaderChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, b *pb.HTTPHeader) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, b)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPHeader(self interface{}, c SpecVisitorContext, b *pb.HTTPHeader, cont Cont) Cont {
@@ -277,7 +306,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPCookie(self interface{}, c SpecVisitorCo
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPCookieChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, ck *pb.HTTPCookie) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, ck)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPCookie(self interface{}, c SpecVisitorContext, ck *pb.HTTPCookie, cont Cont) Cont {
@@ -291,7 +321,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPBody(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPBodyChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, b *pb.HTTPBody) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, b)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPBody(self interface{}, c SpecVisitorContext, b *pb.HTTPBody, cont Cont) Cont {
@@ -305,7 +336,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPEmpty(self interface{}, c SpecVisitorCon
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPEmptyChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, e *pb.HTTPEmpty) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, e)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPEmpty(self interface{}, c SpecVisitorContext, e *pb.HTTPEmpty, cont Cont) Cont {
@@ -319,7 +351,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPAuth(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPAuthChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, a *pb.HTTPAuth) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, a)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPAuth(self interface{}, c SpecVisitorContext, a *pb.HTTPAuth, cont Cont) Cont {
@@ -333,7 +366,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPMultipart(self interface{}, c SpecVisito
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPMultipartChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.HTTPMultipart) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPMultipart(self interface{}, c SpecVisitorContext, m *pb.HTTPMultipart, cont Cont) Cont {
@@ -347,7 +381,13 @@ func (*DefaultSpecVisitorImpl) EnterPrimitive(self interface{}, c SpecVisitorCon
 }
 
 func (*DefaultSpecVisitorImpl) VisitPrimitiveChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.Primitive) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d,
+			"Value", d.Value,
+			"AkitaAnnotations", d.AkitaAnnotations, // TODO: don't recurse into this one?
+		)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeavePrimitive(self interface{}, c SpecVisitorContext, d *pb.Primitive, cont Cont) Cont {
@@ -361,7 +401,13 @@ func (*DefaultSpecVisitorImpl) EnterStruct(self interface{}, c SpecVisitorContex
 }
 
 func (*DefaultSpecVisitorImpl) VisitStructChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.Struct) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d,
+			"Fields", d.Fields,
+			"MapType", d.MapType,
+		)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveStruct(self interface{}, c SpecVisitorContext, d *pb.Struct, cont Cont) Cont {
@@ -375,7 +421,10 @@ func (*DefaultSpecVisitorImpl) EnterList(self interface{}, c SpecVisitorContext,
 }
 
 func (*DefaultSpecVisitorImpl) VisitListChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.List) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d, "Elems", d.Elems)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveList(self interface{}, c SpecVisitorContext, d *pb.List, cont Cont) Cont {
@@ -389,7 +438,10 @@ func (*DefaultSpecVisitorImpl) EnterOptional(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitOptionalChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.Optional) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d, "Value", d.Value)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveOptional(self interface{}, c SpecVisitorContext, d *pb.Optional, cont Cont) Cont {
@@ -403,7 +455,10 @@ func (*DefaultSpecVisitorImpl) EnterOneOf(self interface{}, c SpecVisitorContext
 }
 
 func (*DefaultSpecVisitorImpl) VisitOneOfChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.OneOf) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d, "Options", d.Options)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveOneOf(self interface{}, c SpecVisitorContext, d *pb.OneOf, cont Cont) Cont {

--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -722,6 +722,8 @@ func visitChildren(cin Context, vm VisitorManager, node interface{}) Cont {
 		return v.VisitDataChildren(visitor, ctx, vm, node)
 	case *pb.DataMeta:
 		return v.VisitDataMetaChildren(visitor, ctx, vm, node)
+	case *pb.HTTPMeta:
+		return v.VisitHTTPMetaChildren(visitor, ctx, vm, node)
 	case *pb.HTTPPath:
 		return v.VisitHTTPPathChildren(visitor, ctx, vm, node)
 	case *pb.HTTPQuery:

--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -119,7 +119,7 @@ func (*DefaultSpecVisitorImpl) EnterNode(self interface{}, ctxt SpecVisitorConte
 }
 
 func (*DefaultSpecVisitorImpl) VisitNodeChildren(self interface{}, ctxt SpecVisitorContext, vm VisitorManager, node interface{}) Cont {
-	return go_ast.DefaultVisitChildren(ctxt, vm, node)
+	return DefaultVisitIRChildren(ctxt, vm, node)
 }
 
 func (*DefaultSpecVisitorImpl) LeaveNode(self interface{}, ctxt SpecVisitorContext, node interface{}, cont Cont) Cont {

--- a/visitors/http_rest/spec_visitor_default.go
+++ b/visitors/http_rest/spec_visitor_default.go
@@ -94,7 +94,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 		}
 	case *pb.Data_Struct:
 		if node != nil {
-
 			keepGoing = visitStructMembers(ctx, vm, m, "Struct", node.Struct)
 		}
 	case *pb.Data_List:

--- a/visitors/http_rest/spec_visitor_default.go
+++ b/visitors/http_rest/spec_visitor_default.go
@@ -1,0 +1,316 @@
+package http_rest
+
+import (
+	"fmt"
+
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
+	. "github.com/akitasoftware/akita-libs/visitors"
+	"github.com/akitasoftware/akita-libs/visitors/go_ast"
+)
+
+// This is the default implementation of VisitNodeChildren for DefaultSpecVisitorImpl.
+// It is indirectly called by every Visit____Children that does not override the default method.
+//
+// We need to call the visitor manager on:
+//   Every exported field in a struct, after updating the context with EnterStruct.
+//   Every element of an array, after updating the context with EnterArray.
+//   Every element of a map, after updating the context with EnterMap.
+// Each call to visit may abort the operation.
+//
+// This implementation uses reflection as a fallback, but has specialized methods for common types.
+// GRPC types use the fallback.
+//
+// It looks like the original implementation would call EnterNode/VisitChildren/LeaveNode on basic types.
+// We won't be doing that, as specVisitor's enter/visitChildren/leave methods do not do anything with them.
+//
+func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont {
+	keepGoing := Continue
+
+	// A check for m == nil doesn't work here, because m could be a typed pointer
+	// to nil, which is different than interface{}(nil).
+
+	switch node := m.(type) {
+	case *pb.APISpec:
+		// Methods is a []*Method, but Tags is just map[string]string
+		keepGoing = visitStructMembers(ctx, vm, m, "Methods", node.Methods)
+	case []*pb.Method:
+		for i, m := range node {
+			keepGoing = visitSliceMember(ctx, vm, m, i, node[i])
+			if keepGoing != Continue {
+				break
+			}
+		}
+	case []*pb.Data:
+		// Yes, this is identical to the one above
+		for i, m := range node {
+			keepGoing = visitSliceMember(ctx, vm, m, i, node[i])
+			if keepGoing != Continue {
+				break
+			}
+		}
+	case *pb.Method:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m,
+				"Id", node.Id,
+				"Args", node.Args,
+				"Responses", node.Responses,
+				"Meta", node.Meta,
+			)
+		}
+	case map[string]*pb.Data: // No other maps to non-basic types exist?
+		for k, v := range node {
+			keepGoing = visitMapMember(ctx, vm, m, k, v)
+			if keepGoing != Continue {
+				break
+			}
+		}
+	case *pb.MethodMeta:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Meta", node.Meta)
+		}
+	case *pb.MethodMeta_Http:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Http", node.Http)
+		}
+	case *pb.Data:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m,
+				"Value", node.Value,
+				"Meta", node.Meta,
+				"ExampleValues", node.ExampleValues,
+			)
+		}
+	case *pb.DataMeta:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Meta", node.Meta)
+		}
+	case *pb.DataMeta_Http:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Http", node.Http)
+		}
+	case *pb.Data_Primitive:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Primitive", node.Primitive)
+		}
+	case *pb.Data_Struct:
+		if node != nil {
+
+			keepGoing = visitStructMembers(ctx, vm, m, "Struct", node.Struct)
+		}
+	case *pb.Data_List:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "List", node.List)
+		}
+	case *pb.Data_Optional:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Optional", node.Optional)
+		}
+	case *pb.Data_Oneof:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Oneof", node.Oneof)
+		}
+	case *pb.Primitive:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m,
+				"Value", node.Value,
+				"AkitaAnnotations", node.AkitaAnnotations, // TODO: don't recurse into this one?
+			)
+		}
+	case *pb.AkitaAnnotations:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "FormatOption", node.FormatOption)
+		}
+	case *pb.FormatOption:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Format", node.Format)
+		}
+	case *pb.Primitive_BoolValue:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "BoolValue", node.BoolValue)
+		}
+	case *pb.Primitive_BytesValue:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "BytesValue", node.BytesValue)
+		}
+	case *pb.Primitive_StringValue:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "StringValue", node.StringValue)
+		}
+	case *pb.Primitive_Int32Value:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Int32Value", node.Int32Value)
+		}
+	case *pb.Primitive_Int64Value:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Int64Value", node.Int64Value)
+		}
+	case *pb.Primitive_Uint32Value:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Uint32Value", node.Uint32Value)
+		}
+	case *pb.Primitive_Uint64Value:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Uint64Value", node.Uint64Value)
+		}
+	case *pb.Primitive_DoubleValue:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "DoubleValue", node.DoubleValue)
+		}
+	case *pb.Primitive_FloatValue:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "FloatValue", node.FloatValue)
+		}
+	case *pb.Struct:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m,
+				"Fields", node.Fields, // already handled map[string]*Data
+				"MapType", node.MapType,
+			)
+		}
+	case *pb.MapData:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m,
+				"Key", node.Key,
+				"Value", node.Value,
+			)
+		}
+	case *pb.List:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Elems", node.Elems)
+		}
+	case *pb.Optional:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Value", node.Value)
+		}
+	case *pb.Optional_None:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "None", node.None) // TODO: don't recurse?
+		}
+	case *pb.Optional_Data:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Data", node.Data)
+		}
+	case *pb.OneOf:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Options", node.Options)
+		}
+	// These all have No non-basic types as children, so no further recursion is needed
+	case *pb.MethodID: // FIXME: should we even enter this one? Not used by SpecVisitor
+	case *pb.HTTPMethodMeta:
+	case *pb.HTTPPath:
+	case *pb.HTTPQuery:
+	case *pb.HTTPHeader:
+	case *pb.HTTPCookie:
+	case *pb.HTTPBody:
+	case *pb.HTTPEmpty:
+	case *pb.HTTPAuth:
+	case *pb.HTTPMultipart:
+	case *pb.FormatOption_StringFormat: // only contains a string
+	case *pb.None:
+	default:
+		// Fallback to reflection-based implementation
+		return go_ast.DefaultVisitChildren(ctx, vm, m)
+	}
+	return keepGoing
+}
+
+// Visit the struct members given by <field1> <value1> <field2> <value2>
+func visitStructMembers(ctx Context, vm VisitorManager, inStruct interface{}, fields ...interface{}) Cont {
+	keepGoing := Continue
+	for i := 0; i < len(fields); i += 2 {
+		field := fields[i].(string)
+		value := fields[i+1]
+		// Recurse into the member
+		keepGoing := VisitInterface(ctx.EnterStruct(inStruct, field), vm, value)
+
+		// Validate return value
+		switch keepGoing {
+		case Abort, Stop:
+			return keepGoing
+		case Continue:
+			// fall through and get the next value, if any
+		case SkipChildren:
+			panic("VisitInterface returned SkipChildren")
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+	return keepGoing
+}
+
+func visitSliceMember(ctx Context, vm VisitorManager, inSlice interface{}, index int, value interface{}) Cont {
+	// Recurse into the member
+	keepGoing := VisitInterface(ctx.EnterArray(inSlice, index), vm, value)
+
+	// Validate return value
+	switch keepGoing {
+	case Abort, Stop, Continue:
+		return keepGoing
+	case SkipChildren:
+		panic("VisitInterface returned SkipChildren")
+	default:
+		panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+	}
+}
+
+func visitMapMember(ctx Context, vm VisitorManager, inSlice interface{}, key string, value interface{}) Cont {
+	// Recurse into the member
+	keepGoing := VisitInterface(ctx.EnterMapValue(inSlice, key), vm, value)
+
+	// Validate return value
+	switch keepGoing {
+	case Abort, Stop, Continue:
+		return keepGoing
+	case SkipChildren:
+		panic("VisitInterface returned SkipChildren")
+	default:
+		panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+	}
+}
+
+// Visits the node m of any type, whose context is c. This should never return SkipChildren.
+// Implements all the logic to enter, visit children, and leave, while obeying the visitor's returned
+// Cont value.
+// This is a copy of astVisitor's visit function.
+func VisitInterface(c Context, vm VisitorManager, m interface{}) Cont {
+	if m == nil {
+		return Continue
+	}
+
+	vm.ExtendContext(c, vm.Visitor(), m)
+
+	keepGoing := vm.EnterNode(c, vm.Visitor(), m)
+	switch keepGoing {
+	case Abort:
+		return Abort
+	case Continue:
+	case SkipChildren:
+	case Stop:
+	default:
+		panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+	}
+
+	// Don't visit children if we are stopping or skipping children.
+	if keepGoing == Continue {
+		keepGoing = vm.VisitChildren(c, vm, m)
+		switch keepGoing {
+		case Abort:
+			return Abort
+		case Continue:
+		case SkipChildren:
+			panic("VisitChildren shouldn't return SkipChildren")
+		case Stop:
+		default:
+			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
+		}
+	}
+
+	keepGoing = vm.LeaveNode(c, vm.Visitor(), m, keepGoing)
+
+	// For convenience, convert SkipChildren into Continue, so that LeaveNode
+	// implementations can just return keepGoing unchanged.
+	if keepGoing == SkipChildren {
+		keepGoing = Continue
+	}
+	return keepGoing
+}

--- a/visitors/http_rest/spec_visitor_default.go
+++ b/visitors/http_rest/spec_visitor_default.go
@@ -30,9 +30,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 	// to nil, which is different than interface{}(nil).
 
 	switch node := m.(type) {
-	case *pb.APISpec:
-		// Methods is a []*Method, but Tags is just map[string]string
-		keepGoing = visitStructMembers(ctx, vm, m, "Methods", node.Methods)
 	case []*pb.Method:
 		for i, m := range node {
 			keepGoing = visitSliceMember(ctx, vm, m, i, node[i])
@@ -48,15 +45,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 				break
 			}
 		}
-	case *pb.Method:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m,
-				"Id", node.Id,
-				"Args", node.Args,
-				"Responses", node.Responses,
-				"Meta", node.Meta,
-			)
-		}
 	case map[string]*pb.Data: // No other maps to non-basic types exist?
 		for k, v := range node {
 			keepGoing = visitMapMember(ctx, vm, m, k, v)
@@ -64,25 +52,9 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 				break
 			}
 		}
-	case *pb.MethodMeta:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Meta", node.Meta)
-		}
 	case *pb.MethodMeta_Http:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Http", node.Http)
-		}
-	case *pb.Data:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m,
-				"Value", node.Value,
-				"Meta", node.Meta,
-				"ExampleValues", node.ExampleValues,
-			)
-		}
-	case *pb.DataMeta:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Meta", node.Meta)
 		}
 	case *pb.DataMeta_Http:
 		if node != nil {
@@ -107,13 +79,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 	case *pb.Data_Oneof:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Oneof", node.Oneof)
-		}
-	case *pb.Primitive:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m,
-				"Value", node.Value,
-				"AkitaAnnotations", node.AkitaAnnotations, // TODO: don't recurse into this one?
-			)
 		}
 	case *pb.AkitaAnnotations:
 		if node != nil {
@@ -159,13 +124,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "FloatValue", node.FloatValue)
 		}
-	case *pb.Struct:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m,
-				"Fields", node.Fields, // already handled map[string]*Data
-				"MapType", node.MapType,
-			)
-		}
 	case *pb.MapData:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m,
@@ -173,37 +131,16 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 				"Value", node.Value,
 			)
 		}
-	case *pb.List:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Elems", node.Elems)
-		}
-	case *pb.Optional:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Value", node.Value)
-		}
 	case *pb.Optional_None:
 		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "None", node.None) // TODO: don't recurse?
+			keepGoing = visitStructMembers(ctx, vm, m, "None", node.None)
 		}
 	case *pb.Optional_Data:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Data", node.Data)
 		}
-	case *pb.OneOf:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Options", node.Options)
-		}
 	// These all have No non-basic types as children, so no further recursion is needed
 	case *pb.MethodID: // FIXME: should we even enter this one? Not used by SpecVisitor
-	case *pb.HTTPMethodMeta:
-	case *pb.HTTPPath:
-	case *pb.HTTPQuery:
-	case *pb.HTTPHeader:
-	case *pb.HTTPCookie:
-	case *pb.HTTPBody:
-	case *pb.HTTPEmpty:
-	case *pb.HTTPAuth:
-	case *pb.HTTPMultipart:
 	case *pb.FormatOption_StringFormat: // only contains a string
 	case *pb.None:
 	default:
@@ -272,44 +209,5 @@ func visitMapMember(ctx Context, vm VisitorManager, inSlice interface{}, key str
 // Cont value.
 // This is a copy of astVisitor's visit function.
 func VisitInterface(c Context, vm VisitorManager, m interface{}) Cont {
-	if m == nil {
-		return Continue
-	}
-
-	vm.ExtendContext(c, vm.Visitor(), m)
-
-	keepGoing := vm.EnterNode(c, vm.Visitor(), m)
-	switch keepGoing {
-	case Abort:
-		return Abort
-	case Continue:
-	case SkipChildren:
-	case Stop:
-	default:
-		panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
-	}
-
-	// Don't visit children if we are stopping or skipping children.
-	if keepGoing == Continue {
-		keepGoing = vm.VisitChildren(c, vm, m)
-		switch keepGoing {
-		case Abort:
-			return Abort
-		case Continue:
-		case SkipChildren:
-			panic("VisitChildren shouldn't return SkipChildren")
-		case Stop:
-		default:
-			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
-		}
-	}
-
-	keepGoing = vm.LeaveNode(c, vm.Visitor(), m, keepGoing)
-
-	// For convenience, convert SkipChildren into Continue, so that LeaveNode
-	// implementations can just return keepGoing unchanged.
-	if keepGoing == SkipChildren {
-		keepGoing = Continue
-	}
-	return keepGoing
+	return go_ast.ApplyWithContext(vm, c, m)
 }

--- a/visitors/http_rest/spec_visitor_default.go
+++ b/visitors/http_rest/spec_visitor_default.go
@@ -139,10 +139,50 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Data", node.Data)
 		}
+	case *pb.Bytes:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
+	case *pb.String:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
+	case *pb.Int32:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
+	case *pb.Int64:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
+	case *pb.Uint32:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
+	case *pb.Uint64:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
+	case *pb.Float:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
+	case *pb.Double:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
 	// These all have No non-basic types as children, so no further recursion is needed
 	case *pb.MethodID: // FIXME: should we even enter this one? Not used by SpecVisitor
 	case *pb.FormatOption_StringFormat: // only contains a string
 	case *pb.None:
+	case *pb.StringType:
+	case *pb.BytesType:
+	case *pb.Int32Type:
+	case *pb.Int64Type:
+	case *pb.Uint32Type:
+	case *pb.Uint64Type:
+	case *pb.FloatType:
+	case *pb.DoubleType:
 	default:
 		// Fallback to reflection-based implementation
 		return go_ast.DefaultVisitChildren(ctx, vm, m)

--- a/visitors/http_rest/spec_visitor_default.go
+++ b/visitors/http_rest/spec_visitor_default.go
@@ -45,16 +45,32 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 				break
 			}
 		}
-	case map[string]*pb.Data: // No other maps to non-basic types exist?
+	case map[string]*pb.Data:
 		for k, v := range node {
 			keepGoing = visitMapMember(ctx, vm, m, k, v)
 			if keepGoing != Continue {
 				break
 			}
 		}
+	case map[string]*pb.ExampleValue:
+		// Yes, this is identical to the one above
+		for k, v := range node {
+			keepGoing = visitMapMember(ctx, vm, m, k, v)
+			if keepGoing != Continue {
+				break
+			}
+		}
+	case *pb.Witness:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Method", node.Method)
+		}
 	case *pb.MethodMeta_Http:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Http", node.Http)
+		}
+	case *pb.DataMeta_Grpc:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Grpc", node.Grpc)
 		}
 	case *pb.DataMeta_Http:
 		if node != nil {
@@ -139,6 +155,42 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Data", node.Data)
 		}
+	case *pb.HTTPMeta_Path:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Path", node.Path)
+		}
+	case *pb.HTTPMeta_Query:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Query", node.Query)
+		}
+	case *pb.HTTPMeta_Header:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Header", node.Header)
+		}
+	case *pb.HTTPMeta_Cookie:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Cookie", node.Cookie)
+		}
+	case *pb.HTTPMeta_Body:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Body", node.Body)
+		}
+	case *pb.HTTPMeta_Empty:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Empty", node.Empty)
+		}
+	case *pb.HTTPMeta_Auth:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Auth", node.Auth)
+		}
+	case *pb.HTTPMeta_Multipart:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Multipart", node.Multipart)
+		}
+	case *pb.Bool:
+		if node != nil {
+			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
+		}
 	case *pb.Bytes:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Type", node.Type)
@@ -183,8 +235,10 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 	case *pb.Uint64Type:
 	case *pb.FloatType:
 	case *pb.DoubleType:
+	case *pb.GRPCMeta:
+	case *pb.GRPCMethodMeta:
+	case *pb.ExampleValue:
 	default:
-		// Fallback to reflection-based implementation
 		return go_ast.DefaultVisitChildren(ctx, vm, m)
 	}
 	return keepGoing


### PR DESCRIPTION
New method method uses custom code for each type.
(Finally got it simple enough that it *could* be automated.)
