### PR TITLE
Refactored

### DIFF
--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -137,7 +137,8 @@ func (*DefaultSpecVisitorImpl) EnterAPISpec(self interface{}, c SpecVisitorConte
 }
 
 func (*DefaultSpecVisitorImpl) VisitAPISpecChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, spec *pb.APISpec) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, spec)
+	// Methods is a []*Method, but Tags is just map[string]string
+	return visitStructMembers(c, vm, spec, "Methods", spec.Methods)
 }
 
 func (*DefaultSpecVisitorImpl) LeaveAPISpec(self interface{}, c SpecVisitorContext, spec *pb.APISpec, cont Cont) Cont {
@@ -151,7 +152,15 @@ func (*DefaultSpecVisitorImpl) EnterMethod(self interface{}, c SpecVisitorContex
 }
 
 func (*DefaultSpecVisitorImpl) VisitMethodChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.Method) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	if m != nil {
+		return visitStructMembers(c, vm, m,
+			"Id", m.Id,
+			"Args", m.Args,
+			"Responses", m.Responses,
+			"Meta", m.Meta,
+		)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveMethod(self interface{}, c SpecVisitorContext, m *pb.Method, cont Cont) Cont {
@@ -165,7 +174,10 @@ func (*DefaultSpecVisitorImpl) EnterMethodMeta(self interface{}, c SpecVisitorCo
 }
 
 func (*DefaultSpecVisitorImpl) VisitMethodMetaChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.MethodMeta) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	if m != nil {
+		return visitStructMembers(c, vm, m, "Meta", m.Meta)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveMethodMeta(self interface{}, c SpecVisitorContext, m *pb.MethodMeta, cont Cont) Cont {
@@ -179,7 +191,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPMethodMeta(self interface{}, c SpecVisit
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPMethodMetaChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.HTTPMethodMeta) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPMethodMeta(self interface{}, c SpecVisitorContext, m *pb.HTTPMethodMeta, cont Cont) Cont {
@@ -193,7 +206,14 @@ func (*DefaultSpecVisitorImpl) EnterData(self interface{}, c SpecVisitorContext,
 }
 
 func (*DefaultSpecVisitorImpl) VisitDataChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.Data) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d,
+			"Value", d.Value,
+			"Meta", d.Meta,
+			"ExampleValues", d.ExampleValues,
+		)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveData(self interface{}, c SpecVisitorContext, d *pb.Data, cont Cont) Cont {
@@ -207,7 +227,10 @@ func (*DefaultSpecVisitorImpl) EnterDataMeta(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitDataMetaChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.DataMeta) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d, "Meta", d.Meta)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveDataMeta(self interface{}, c SpecVisitorContext, d *pb.DataMeta, cont Cont) Cont {
@@ -221,7 +244,10 @@ func (*DefaultSpecVisitorImpl) EnterHTTPMeta(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPMetaChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.HTTPMeta) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	if m != nil {
+		return visitStructMembers(c, vm, m, "Location", m.Location)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPMeta(self interface{}, c SpecVisitorContext, m *pb.HTTPMeta, cont Cont) Cont {
@@ -235,7 +261,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPPath(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPPathChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, p *pb.HTTPPath) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, p)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPPath(self interface{}, c SpecVisitorContext, p *pb.HTTPPath, cont Cont) Cont {
@@ -249,7 +276,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPQuery(self interface{}, c SpecVisitorCon
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPQueryChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, q *pb.HTTPQuery) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, q)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPQuery(self interface{}, c SpecVisitorContext, q *pb.HTTPQuery, cont Cont) Cont {
@@ -263,7 +291,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPHeader(self interface{}, c SpecVisitorCo
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPHeaderChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, b *pb.HTTPHeader) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, b)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPHeader(self interface{}, c SpecVisitorContext, b *pb.HTTPHeader, cont Cont) Cont {
@@ -277,7 +306,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPCookie(self interface{}, c SpecVisitorCo
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPCookieChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, ck *pb.HTTPCookie) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, ck)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPCookie(self interface{}, c SpecVisitorContext, ck *pb.HTTPCookie, cont Cont) Cont {
@@ -291,7 +321,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPBody(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPBodyChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, b *pb.HTTPBody) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, b)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPBody(self interface{}, c SpecVisitorContext, b *pb.HTTPBody, cont Cont) Cont {
@@ -305,7 +336,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPEmpty(self interface{}, c SpecVisitorCon
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPEmptyChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, e *pb.HTTPEmpty) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, e)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPEmpty(self interface{}, c SpecVisitorContext, e *pb.HTTPEmpty, cont Cont) Cont {
@@ -319,7 +351,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPAuth(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPAuthChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, a *pb.HTTPAuth) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, a)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPAuth(self interface{}, c SpecVisitorContext, a *pb.HTTPAuth, cont Cont) Cont {
@@ -333,7 +366,8 @@ func (*DefaultSpecVisitorImpl) EnterHTTPMultipart(self interface{}, c SpecVisito
 }
 
 func (*DefaultSpecVisitorImpl) VisitHTTPMultipartChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, m *pb.HTTPMultipart) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, m)
+	// No child nodes to visit: only has primitives.
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveHTTPMultipart(self interface{}, c SpecVisitorContext, m *pb.HTTPMultipart, cont Cont) Cont {
@@ -347,7 +381,13 @@ func (*DefaultSpecVisitorImpl) EnterPrimitive(self interface{}, c SpecVisitorCon
 }
 
 func (*DefaultSpecVisitorImpl) VisitPrimitiveChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.Primitive) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d,
+			"Value", d.Value,
+			"AkitaAnnotations", d.AkitaAnnotations, // TODO: don't recurse into this one?
+		)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeavePrimitive(self interface{}, c SpecVisitorContext, d *pb.Primitive, cont Cont) Cont {
@@ -361,7 +401,13 @@ func (*DefaultSpecVisitorImpl) EnterStruct(self interface{}, c SpecVisitorContex
 }
 
 func (*DefaultSpecVisitorImpl) VisitStructChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.Struct) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d,
+			"Fields", d.Fields,
+			"MapType", d.MapType,
+		)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveStruct(self interface{}, c SpecVisitorContext, d *pb.Struct, cont Cont) Cont {
@@ -375,7 +421,10 @@ func (*DefaultSpecVisitorImpl) EnterList(self interface{}, c SpecVisitorContext,
 }
 
 func (*DefaultSpecVisitorImpl) VisitListChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.List) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d, "Elems", d.Elems)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveList(self interface{}, c SpecVisitorContext, d *pb.List, cont Cont) Cont {
@@ -389,7 +438,10 @@ func (*DefaultSpecVisitorImpl) EnterOptional(self interface{}, c SpecVisitorCont
 }
 
 func (*DefaultSpecVisitorImpl) VisitOptionalChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.Optional) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d, "Value", d.Value)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveOptional(self interface{}, c SpecVisitorContext, d *pb.Optional, cont Cont) Cont {
@@ -403,7 +455,10 @@ func (*DefaultSpecVisitorImpl) EnterOneOf(self interface{}, c SpecVisitorContext
 }
 
 func (*DefaultSpecVisitorImpl) VisitOneOfChildren(self interface{}, c SpecVisitorContext, vm VisitorManager, d *pb.OneOf) Cont {
-	return self.(DefaultSpecVisitor).VisitNodeChildren(self, c, vm, d)
+	if d != nil {
+		return visitStructMembers(c, vm, d, "Options", d.Options)
+	}
+	return Continue
 }
 
 func (*DefaultSpecVisitorImpl) LeaveOneOf(self interface{}, c SpecVisitorContext, d *pb.OneOf, cont Cont) Cont {

--- a/visitors/http_rest/spec_visitor_default.go
+++ b/visitors/http_rest/spec_visitor_default.go
@@ -209,44 +209,5 @@ func visitMapMember(ctx Context, vm VisitorManager, inSlice interface{}, key str
 // Cont value.
 // This is a copy of astVisitor's visit function.
 func VisitInterface(c Context, vm VisitorManager, m interface{}) Cont {
-	if m == nil {
-		return Continue
-	}
-
-	vm.ExtendContext(c, vm.Visitor(), m)
-
-	keepGoing := vm.EnterNode(c, vm.Visitor(), m)
-	switch keepGoing {
-	case Abort:
-		return Abort
-	case Continue:
-	case SkipChildren:
-	case Stop:
-	default:
-		panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
-	}
-
-	// Don't visit children if we are stopping or skipping children.
-	if keepGoing == Continue {
-		keepGoing = vm.VisitChildren(c, vm, m)
-		switch keepGoing {
-		case Abort:
-			return Abort
-		case Continue:
-		case SkipChildren:
-			panic("VisitChildren shouldn't return SkipChildren")
-		case Stop:
-		default:
-			panic(fmt.Sprintf("Unknown Cont value: %d", keepGoing))
-		}
-	}
-
-	keepGoing = vm.LeaveNode(c, vm.Visitor(), m, keepGoing)
-
-	// For convenience, convert SkipChildren into Continue, so that LeaveNode
-	// implementations can just return keepGoing unchanged.
-	if keepGoing == SkipChildren {
-		keepGoing = Continue
-	}
-	return keepGoing
+	return go_ast.ApplyWithContext(vm, c, m)
 }

--- a/visitors/http_rest/spec_visitor_default.go
+++ b/visitors/http_rest/spec_visitor_default.go
@@ -30,9 +30,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 	// to nil, which is different than interface{}(nil).
 
 	switch node := m.(type) {
-	case *pb.APISpec:
-		// Methods is a []*Method, but Tags is just map[string]string
-		keepGoing = visitStructMembers(ctx, vm, m, "Methods", node.Methods)
 	case []*pb.Method:
 		for i, m := range node {
 			keepGoing = visitSliceMember(ctx, vm, m, i, node[i])
@@ -48,15 +45,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 				break
 			}
 		}
-	case *pb.Method:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m,
-				"Id", node.Id,
-				"Args", node.Args,
-				"Responses", node.Responses,
-				"Meta", node.Meta,
-			)
-		}
 	case map[string]*pb.Data: // No other maps to non-basic types exist?
 		for k, v := range node {
 			keepGoing = visitMapMember(ctx, vm, m, k, v)
@@ -64,25 +52,9 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 				break
 			}
 		}
-	case *pb.MethodMeta:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Meta", node.Meta)
-		}
 	case *pb.MethodMeta_Http:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Http", node.Http)
-		}
-	case *pb.Data:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m,
-				"Value", node.Value,
-				"Meta", node.Meta,
-				"ExampleValues", node.ExampleValues,
-			)
-		}
-	case *pb.DataMeta:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Meta", node.Meta)
 		}
 	case *pb.DataMeta_Http:
 		if node != nil {
@@ -107,13 +79,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 	case *pb.Data_Oneof:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Oneof", node.Oneof)
-		}
-	case *pb.Primitive:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m,
-				"Value", node.Value,
-				"AkitaAnnotations", node.AkitaAnnotations, // TODO: don't recurse into this one?
-			)
 		}
 	case *pb.AkitaAnnotations:
 		if node != nil {
@@ -159,13 +124,6 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "FloatValue", node.FloatValue)
 		}
-	case *pb.Struct:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m,
-				"Fields", node.Fields, // already handled map[string]*Data
-				"MapType", node.MapType,
-			)
-		}
 	case *pb.MapData:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m,
@@ -173,37 +131,16 @@ func DefaultVisitIRChildren(ctx Context, vm VisitorManager, m interface{}) Cont 
 				"Value", node.Value,
 			)
 		}
-	case *pb.List:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Elems", node.Elems)
-		}
-	case *pb.Optional:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Value", node.Value)
-		}
 	case *pb.Optional_None:
 		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "None", node.None) // TODO: don't recurse?
+			keepGoing = visitStructMembers(ctx, vm, m, "None", node.None)
 		}
 	case *pb.Optional_Data:
 		if node != nil {
 			keepGoing = visitStructMembers(ctx, vm, m, "Data", node.Data)
 		}
-	case *pb.OneOf:
-		if node != nil {
-			keepGoing = visitStructMembers(ctx, vm, m, "Options", node.Options)
-		}
 	// These all have No non-basic types as children, so no further recursion is needed
 	case *pb.MethodID: // FIXME: should we even enter this one? Not used by SpecVisitor
-	case *pb.HTTPMethodMeta:
-	case *pb.HTTPPath:
-	case *pb.HTTPQuery:
-	case *pb.HTTPHeader:
-	case *pb.HTTPCookie:
-	case *pb.HTTPBody:
-	case *pb.HTTPEmpty:
-	case *pb.HTTPAuth:
-	case *pb.HTTPMultipart:
 	case *pb.FormatOption_StringFormat: // only contains a string
 	case *pb.None:
 	default:


### PR DESCRIPTION
Moved some functionality out of `DefaultVisitIRChildren`. Functionality specific to node types for which we have a visit-children method belongs in that method.

Deduplicated code in `VisitInterface`.