### PR TITLE
Fix check for OneOf type while building field path.

### DIFF
--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -598,7 +598,7 @@ func extendContext(cin Context, node interface{}) {
 					}
 
 					switch astGrandparent := astGrandparent.(type) {
-					case pb.OneOf:
+					case *pb.OneOf:
 						// Visiting a child of a OneOf. The name will be a meaningless hash
 						// of the Data being visited. Instead, use a OneOfVariant to
 						// represent the field path. To find the index of the OneOfVariant,

--- a/visitors/testdata/contains_oneof.pb.txt
+++ b/visitors/testdata/contains_oneof.pb.txt
@@ -1,0 +1,69 @@
+methods: <
+  id: <
+    api_type: HTTP_REST
+  >
+  responses: <
+    key: "XOIWJY1JAvI="
+    value: <
+      struct: <
+         fields: <
+            key: "result"
+            value: <
+              oneof: <
+                options: <
+                  key: "0ChzXURDSRY="
+                  value: <
+                    primitive: <
+                      string_value: <
+                      >
+                    >
+                  >
+                >
+                options: <
+                  key: "va5tP-fnZF8="
+                  value: <
+                    primitive: <
+                      int64_value: <
+                      >
+                    >
+                  >
+                >
+              >
+            >
+         >
+      >
+      meta: <
+        http: <
+          body: <
+            content_type: JSON
+          >
+          response_code: 200
+        >
+      >
+    >
+  >
+  responses: <
+    key: "x2PuS2JNXDI="
+    value: <
+      primitive: <
+        string_value: <
+        >
+      >
+      meta: <
+        http: <
+          header: <
+            key: "X-Request-Id"
+          >
+          response_code: 200
+        >
+      >
+    >
+  >
+  meta: <
+    http: <
+      method: "GET"
+      path_template: "/api/example"
+      host: "localhost:8080"
+    >
+  >
+>


### PR DESCRIPTION
I _think_ this is fallout from the default spec visitor refactor (to avoid reflection) but I don't entirely see the whole chain of causation. Are there other places we should look for the same sort of problem?

It seems difficult to check for both the struct type and the pointer here without some major surgery...