### PR TITLE
Add explicit go-pg type annotations for ServiceID

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -39,7 +39,7 @@ type APISpecVersion struct {
 
 	Name         string         `pg:"name" json:"name"`
 	APISpecID    akid.APISpecID `pg:"api_spec_id" json:"api_spec_id"`
-	ServiceID    akid.ServiceID `pg:"service_id" json:"service_id"`
+	ServiceID    akid.ServiceID `pg:"service_id,type:uuid" json:"service_id"`
 	CreationTime time.Time      `pg:"creation_time" json:"creation_time"`
 }
 


### PR DESCRIPTION
This is the result of adding a bulk update against a table with a ServiceID column. Without this type annotation on that table, the ServiceID in the bulk update is encoded as JSON, resulting in Postgres rejecting the update due to a type error. Furthermore, once this annotation is added to that table, it needs to be propagated to all ServiceID columns, or else joins don't work. 😞