### PR TITLE
Fix melding of one-ofs

### DIFF
--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -2,6 +2,7 @@ package spec_util
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/golang/protobuf/proto"
@@ -196,6 +197,8 @@ func (m *melder) meldData(dst, src *pb.Data) (retErr error) {
 			// If src is a none, drop the none and mark the dst value as optional.
 			makeOptional(dst)
 			return nil
+		default:
+			return fmt.Errorf("unknown optional value type: %s", reflect.TypeOf(srcOpt.Optional.Value).Name())
 		}
 	}
 
@@ -237,7 +240,7 @@ func (m *melder) meldData(dst, src *pb.Data) (retErr error) {
 			}
 			return nil
 		default:
-			return m.recordConflict(dst, src)
+			return fmt.Errorf("unknown optional value type: %s", reflect.TypeOf(v.Optional.Value).Name())
 		}
 	case *pb.Data_Oneof:
 		hasConflict = true

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -149,6 +149,13 @@ type melder struct {
 	mergeTracking bool
 }
 
+// If the given src and dst have the following invariant on all OneOfs contained
+// within, then this is preserved.
+//
+//   - At most one variant in the OneOf is a struct.
+//   - At most one variant in the OneOf is a list.
+//   - All other variants in the OneOf is a primitive.
+//
 // Assumes that dst.Meta == src.Meta.
 //
 // XXX: In some cases, this modifies src as well as dst :/

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -114,6 +114,24 @@ var tests = []testData{
 		"testdata/meld/meld_oneof_with_primitive_expected.pb.txt",
 	},
 	{
+		"melding oneof with itself is idempotent",
+		[]string{
+			"testdata/meld/meld_oneof_with_oneof_1.pb.txt",
+			"testdata/meld/meld_oneof_with_oneof_1.pb.txt",
+		},
+		"testdata/meld/meld_oneof_with_oneof_1.pb.txt",
+	},
+	{
+		// meld(oneof(list<L1>, S1), oneof(list<L2>, S2))
+		//   => oneof(list<meld(L1, L2)>, meld(S1, S2))
+		"meld oneof with oneof",
+		[]string{
+			"testdata/meld/meld_oneof_with_oneof_1.pb.txt",
+			"testdata/meld/meld_oneof_with_oneof_2.pb.txt",
+		},
+		"testdata/meld/meld_oneof_with_oneof_expected.pb.txt",
+	},
+	{
 		"meld struct",
 		[]string{
 			"testdata/meld/meld_struct_1.pb.txt",

--- a/spec_util/testdata/meld/meld_oneof_with_oneof_1.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_oneof_1.pb.txt
@@ -2,7 +2,7 @@
 
 method: {
   responses: {
-    key:"c-G2EGYXkIg="
+    key:"xsMpke-69_I="
     value: {
       struct: {
         fields: {
@@ -29,7 +29,7 @@ method: {
                 }
               }
               options: {
-                key: "unknown1"
+                key: "jdL6rEEOgqs="
                 value: {
                   list: {
                     elems: {

--- a/spec_util/testdata/meld/meld_oneof_with_oneof_1.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_oneof_1.pb.txt
@@ -1,0 +1,77 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"c-G2EGYXkIg="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key: "VNe7F7DBhNg="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {}
+                          formats: {
+                            key: "ISOYearMonth"
+                            value: true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "unknown1"
+                value: {
+                  list: {
+                    elems: {
+                      struct: {
+                        fields: {
+                          key: "name"
+                          value: {
+                            primitive: {
+                              string_value: {}
+                            }
+                          }
+                        }
+                        fields: {
+                          key: "number"
+                          value: {
+                            primitive: {
+                              int64_value: {}
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_oneof_with_oneof_2.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_oneof_2.pb.txt
@@ -1,0 +1,77 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"sV9NBujPP7E="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key: "BC8hZFUbQsg="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "c_VUFHuXtlo="
+                value: {
+                  list: {
+                    elems: {
+                      struct: {
+                        fields: {
+                          key: "name"
+                          value: {
+                            primitive: {
+                              string_value: {}
+                            }
+                          }
+                        }
+                        fields: {
+                          key: "number"
+                          value: {
+                            optional: {
+                              data: {
+                                primitive: {
+                                  int64_value: {}
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_oneof_with_oneof_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_oneof_expected.pb.txt
@@ -1,0 +1,81 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"cyDYzRlAiDc="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key: "VNe7F7DBhNg="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {}
+                          formats: {
+                            key: "ISOYearMonth"
+                            value: true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "c_VUFHuXtlo="
+                value: {
+                  list: {
+                    elems: {
+                      struct: {
+                        fields: {
+                          key: "name"
+                          value: {
+                            primitive: {
+                              string_value: {}
+                            }
+                          }
+                        }
+                        fields: {
+                          key: "number"
+                          value: {
+                            optional: {
+                              data: {
+                                primitive: {
+                                  int64_value: {}
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}


### PR DESCRIPTION
Previously, when melding one-ofs together, the variants were just lumped together. Now, we go deeper into the one-ofs by ensuring that any variants that are structs get melded together, and similarly for variants that are lists.