### PR TITLE
When melding primitives, join up the type lattice

### DIFF
--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -279,9 +279,7 @@ func haveCompatibleTypes(dst, src *pb.Primitive) bool {
 
 	// Types are compatible if the base types can join and the format kinds
 	// are equal.
-	cmpDst := &pb.Primitive{Value: baseJoin.Value, FormatKind: dst.FormatKind}
-	cmpSrc := &pb.Primitive{Value: baseJoin.Value, FormatKind: src.FormatKind}
-	if proto.Equal(cmpDst, cmpSrc) {
+	if dst.FormatKind == src.FormatKind {
 		return true
 	}
 
@@ -305,6 +303,9 @@ func joinBaseTypes(dst, src *pb.Primitive) *pb.Primitive {
 		return &pb.Primitive{Value: dst.Value}
 	}
 
+	// NOTE(cns): When the CLI builds witnesses from wire traffic, it parses integers
+	// as int64 whenever possible and only falls back to uint64 for values >= 2^63.
+	// However, we could see other behavior from uploaded specs.
 	switch dst.Value.(type) {
 	case *pb.Primitive_Int32Value:
 		switch src.Value.(type) {

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -359,7 +359,10 @@ func (m *melder) recordConflict(dst, src *pb.Data) error {
 
 	if arePrims && haveCompatibleTypes(dstPrim, srcPrim) {
 		// No conflict.  Merge primitive metadata.
-		m.meldPrimitive(dstPrim, srcPrim)
+		err := m.meldPrimitive(dstPrim, srcPrim)
+		if err != nil {
+			return err
+		}
 		mergeExampleValues(dst, src)
 	} else {
 		// New conflict detected. Create oneof to record the conflict.

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -702,9 +702,13 @@ func (m *melder) meldOneOfVariant(dst *pb.OneOf, srcHash *string, srcVariant *pb
 		}
 
 	case *pb.Data_Primitive:
-		// Fall through.
-		//
-		// XXX TODO Merge with existing primitive variants.
+		// If the destination has a primitive variant that has a compatible type
+		// with the source variant, meld them.  Otherwise, fall through.
+		for oldDstHash, dstVariant := range dst.Options {
+			if _, dstIsPrim := dstVariant.Value.(*pb.Data_Primitive); dstIsPrim && haveCompatibleTypes(dstVariant.GetPrimitive(), srcVariant.GetPrimitive()) {
+				return m.meldAndRehashOption(dst, oldDstHash, dstVariant, srcVariant)
+			}
+		}
 
 	default:
 		return fmt.Errorf("unknown one-of variant type: %s", reflect.TypeOf(srcVariant.Value).Name())

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -271,9 +271,76 @@ func haveCompatibleTypes(dst, src *pb.Primitive) bool {
 		return false
 	}
 
-	cmpDst := &pb.Primitive{Value: dst.Value, FormatKind: dst.FormatKind}
-	cmpSrc := &pb.Primitive{Value: src.Value, FormatKind: src.FormatKind}
-	return proto.Equal(cmpDst, cmpSrc)
+	// First, check that the base types can join.
+	baseJoin := joinBaseTypes(dst, src)
+	if baseJoin == nil {
+		return false
+	}
+
+	// Types are compatible if the base types can join and the format kinds
+	// are equal.
+	cmpDst := &pb.Primitive{Value: baseJoin.Value, FormatKind: dst.FormatKind}
+	cmpSrc := &pb.Primitive{Value: baseJoin.Value, FormatKind: src.FormatKind}
+	if proto.Equal(cmpDst, cmpSrc) {
+		return true
+	}
+
+	// Types are compatible if the base types can join and least one type does
+	// not have any data formats identified.
+	if dst.FormatKind == "" || src.FormatKind == "" {
+		return true
+	}
+
+	return false
+}
+
+// Returns a new Primitive with the Value set as the type-theoretic join of
+// dst.Value and src.Value.  For example, join(int32, uint32) = int64.
+// Returns nil if no such join exists, e.g. join(int64, uint64) = nil.
+func joinBaseTypes(dst, src *pb.Primitive) *pb.Primitive {
+	dstType := reflect.TypeOf(dst.Value)
+	srcType := reflect.TypeOf(src.Value)
+
+	if dstType == srcType {
+		return &pb.Primitive{Value: dst.Value}
+	}
+
+	switch dst.Value.(type) {
+	case *pb.Primitive_Int32Value:
+		switch src.Value.(type) {
+		case *pb.Primitive_Int64Value, *pb.Primitive_Uint32Value:
+			return &pb.Primitive{Value: &pb.Primitive_Int64Value{Int64Value: &pb.Int64{}}}
+		}
+	case *pb.Primitive_Int64Value:
+		switch src.Value.(type) {
+		case *pb.Primitive_Int32Value, *pb.Primitive_Uint32Value:
+			return &pb.Primitive{Value: &pb.Primitive_Int64Value{Int64Value: &pb.Int64{}}}
+		}
+	case *pb.Primitive_Uint32Value:
+		switch src.Value.(type) {
+		case *pb.Primitive_Int32Value:
+			return &pb.Primitive{Value: &pb.Primitive_Int64Value{Int64Value: &pb.Int64{}}}
+		case *pb.Primitive_Uint64Value:
+			return &pb.Primitive{Value: &pb.Primitive_Uint64Value{Uint64Value: &pb.Uint64{}}}
+		}
+	case *pb.Primitive_Uint64Value:
+		switch src.Value.(type) {
+		case *pb.Primitive_Uint32Value:
+			return &pb.Primitive{Value: &pb.Primitive_Uint64Value{Uint64Value: &pb.Uint64{}}}
+		}
+	case *pb.Primitive_FloatValue:
+		switch src.Value.(type) {
+		case *pb.Primitive_DoubleValue:
+			return &pb.Primitive{Value: &pb.Primitive_DoubleValue{DoubleValue: &pb.Double{}}}
+		}
+	case *pb.Primitive_DoubleValue:
+		switch src.Value.(type) {
+		case *pb.Primitive_FloatValue:
+			return &pb.Primitive{Value: &pb.Primitive_DoubleValue{DoubleValue: &pb.Double{}}}
+		}
+	}
+
+	return nil
 }
 
 // Merges src into dst.  Introduces a OneOf when dst and src are different
@@ -510,7 +577,7 @@ func (m *melder) meldList(dst, src *pb.List) error {
 // Assumes dst.value == src.value.
 // Meld data formats, tracking data, etc. from src to dst.
 // XXX(cns): In some cases, this modifies src as well as dst :/
-func (m *melder) meldPrimitive(dst, src *pb.Primitive) {
+func (m *melder) meldPrimitive(dst, src *pb.Primitive) error {
 	// Special case: If and only if one data has a type hint, assign it to the other
 	// data so that the difference does not trigger a conflict and the type hint is preserved.
 	// XXX(cns): This modifies src!  Not ideal, but I don't know if it's safe
@@ -525,17 +592,37 @@ func (m *melder) meldPrimitive(dst, src *pb.Primitive) {
 		}
 	}
 
-	// Merge data formats
-	mergedDataFormats := make(map[string]bool, len(src.Formats)+len(dst.Formats))
-	for k := range src.Formats {
-		mergedDataFormats[k] = true
+	// Join base types.
+	baseJoin := joinBaseTypes(dst, src)
+	if baseJoin == nil {
+		return errors.Errorf("failed to join base types")
 	}
-	for k := range dst.Formats {
-		mergedDataFormats[k] = true
+	dst.Value = baseJoin.Value
+
+	// If either side has no data formats (i.e. is just a base type), then
+	// the resulting meld will similarly have no data formats.  This implements
+	// a type-theoretic join, as the base type without formats subsumes one
+	// restricted to specific formats.
+	if dst.FormatKind == "" || src.FormatKind == "" {
+		dst.FormatKind = ""
+		dst.Formats = nil
+	} else if dst.FormatKind == src.FormatKind {
+		// Merge data formats
+		mergedDataFormats := make(map[string]bool, len(src.Formats)+len(dst.Formats))
+		for k := range src.Formats {
+			mergedDataFormats[k] = true
+		}
+		for k := range dst.Formats {
+			mergedDataFormats[k] = true
+		}
+		if len(mergedDataFormats) > 0 {
+			dst.Formats = mergedDataFormats
+		}
+	} else {
+		return errors.Errorf("failed to meld primitives because format kinds are not equal")
 	}
-	if len(mergedDataFormats) > 0 {
-		dst.Formats = mergedDataFormats
-	}
+
+	return nil
 }
 
 func (m *melder) meldOneOf(dst, src *pb.OneOf) error {

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -23,7 +23,7 @@ var tests = []testData{
 			"testdata/meld/meld_no_data_formats.pb.txt",
 			"testdata/meld/meld_data_formats_1.pb.txt",
 		},
-		"testdata/meld/meld_data_formats_1.pb.txt",
+		"testdata/meld/meld_no_data_formats.pb.txt",
 	},
 	{
 		"format, format",

--- a/spec_util/testdata/meld/meld_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_4xx_expected.pb.txt
@@ -34,7 +34,7 @@ method: {
     }
   }
   responses: {
-    key: "UkEwED5h2s0="
+    key: "8xoNiapias8="
     value: {
       struct: {
         fields: {
@@ -44,6 +44,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_conflict_1.pb.txt
+++ b/spec_util/testdata/meld/meld_conflict_1.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       struct: {
         fields: {
@@ -19,6 +19,7 @@ method: {
               string_value: {
                 value: "2020-01"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_conflict_2.pb.txt
+++ b/spec_util/testdata/meld/meld_conflict_2.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       struct: {
         fields: {
@@ -19,6 +19,7 @@ method: {
               int32_value: {
                 value: 20200101
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true

--- a/spec_util/testdata/meld/meld_conflict_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_conflict_expected.pb.txt
@@ -2,7 +2,7 @@
 
 method: {
   responses: {
-    key:"6JrDs8poHbU="
+    key:"5lXZpTmMTA4="
     value: {
       struct: {
         fields: {
@@ -10,12 +10,13 @@ method: {
           value: {
             oneof: {
               options: {
-                key:"H--6VaA31gw="
+                key:"mLWEQVrb4q0="
                 value: {
                   primitive: {
                     string_value: {
                       value:"2020-01"
                     }
+                    format_kind: "datetime"
                     formats: {
                       key:"ISOYearMonth"
                       value:true
@@ -24,12 +25,13 @@ method: {
                 }
               }
               options: {
-                key:"PGYGe9fHTG4="
+                key:"qA_gQjz1FIY="
                 value: {
                   primitive: {
                     int32_value: {
                       value:20200101
                     }
+                    format_kind: "datetime"
                     formats: {
                       key:"ISOYearMonthDay"
                       value:true

--- a/spec_util/testdata/meld/meld_data_formats_1.pb.txt
+++ b/spec_util/testdata/meld/meld_data_formats_1.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       struct: {
         fields: {
@@ -19,6 +19,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_data_formats_2.pb.txt
+++ b/spec_util/testdata/meld/meld_data_formats_2.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       struct: {
         fields: {
@@ -19,6 +19,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true

--- a/spec_util/testdata/meld/meld_data_formats_3.pb.txt
+++ b/spec_util/testdata/meld/meld_data_formats_3.pb.txt
@@ -9,7 +9,7 @@ method: {
     }
   }
   responses: {
-    key: "KOv-1LTHEKs="
+    key: "VHGmevV8BLM="
     value: {
       struct: {
         fields: {
@@ -19,6 +19,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_data_kind_1.pb.txt
+++ b/spec_util/testdata/meld/meld_data_kind_1.pb.txt
@@ -9,15 +9,15 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       primitive: {
         string_value: {}
+        format_kind: "datetime"
         formats: {
           key: "ISOYearMonth"
           value: true
         }
-        format_kind: "kind1"
       }
       meta: {
         http: {

--- a/spec_util/testdata/meld/meld_data_kind_2.pb.txt
+++ b/spec_util/testdata/meld/meld_data_kind_2.pb.txt
@@ -9,15 +9,15 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       primitive: {
         string_value: {}
+        format_kind: "phone_number"
         formats: {
           key: "Phone"
           value: true
         }
-        format_kind: "kind2"
       }
       meta: {
         http: {

--- a/spec_util/testdata/meld/meld_data_kind_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_data_kind_expected.pb.txt
@@ -9,24 +9,11 @@ method: {
     }
   }
   responses: {
-    key: "sTH-Tl_dPYw="
+    key: "JOj-ikB_ux4="
     value: {
       oneof: {
         options: {
-          key: "VVgfwIsWxHs="
-          value: {
-            primitive: {
-              string_value: {}
-              formats: {
-                key:"ISOYearMonth"
-                value:true
-              }
-              format_kind: "kind1"
-            }
-          }
-        }
-        options: {
-          key: "aZ5HLJXlqk4="
+          key: "0cgpNm_cci8="
           value: {
             primitive: {
               string_value: {}
@@ -34,7 +21,20 @@ method: {
                 key:"Phone"
                 value:true
               }
-              format_kind: "kind2"
+              format_kind: "phone_number"
+            }
+          }
+        }
+        options: {
+          key: "BTe91947u7k="
+          value: {
+            primitive: {
+              string_value: {}
+              formats: {
+                key:"ISOYearMonth"
+                value:true
+              }
+              format_kind: "datetime"
             }
           }
         }

--- a/spec_util/testdata/meld/meld_examples_1.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_1.pb.txt
@@ -30,7 +30,7 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       struct: {
         fields: {
@@ -40,6 +40,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_examples_2.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_2.pb.txt
@@ -30,7 +30,7 @@ method: {
     }
   }
   responses: {
-    key: "oFUqCcv3wkM="
+    key: "kU5J_jopwLg="
     value: {
       struct: {
         fields: {
@@ -40,6 +40,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true

--- a/spec_util/testdata/meld/meld_examples_3.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_3.pb.txt
@@ -34,7 +34,7 @@ method: {
     }
   }
   responses: {
-    key: "KOv-1LTHEKs="
+    key: "VHGmevV8BLM="
     value: {
       struct: {
         fields: {
@@ -44,6 +44,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_examples_4xx_1.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_4xx_1.pb.txt
@@ -40,6 +40,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_examples_4xx_2.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_4xx_2.pb.txt
@@ -30,7 +30,7 @@ method: {
     }
   }
   responses: {
-    key: "ui5EpupUcWM="
+    key: "tZr-XY4VUbM="
     value: {
       struct: {
         fields: {
@@ -40,6 +40,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true

--- a/spec_util/testdata/meld/meld_examples_big_1.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_big_1.pb.txt
@@ -38,7 +38,7 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       struct: {
         fields: {
@@ -48,6 +48,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_examples_big_2.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_big_2.pb.txt
@@ -38,7 +38,7 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       struct: {
         fields: {
@@ -48,6 +48,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true

--- a/spec_util/testdata/meld/meld_examples_big_3.pb.txt
+++ b/spec_util/testdata/meld/meld_examples_big_3.pb.txt
@@ -34,7 +34,7 @@ method: {
     }
   }
   responses: {
-    key: "KOv-1LTHEKs="
+    key: "VHGmevV8BLM="
     value: {
       struct: {
         fields: {
@@ -44,6 +44,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_no_examples_1.pb.txt
+++ b/spec_util/testdata/meld/meld_no_examples_1.pb.txt
@@ -40,6 +40,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_no_examples_2.pb.txt
+++ b/spec_util/testdata/meld/meld_no_examples_2.pb.txt
@@ -36,6 +36,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true

--- a/spec_util/testdata/meld/meld_no_examples_3.pb.txt
+++ b/spec_util/testdata/meld/meld_no_examples_3.pb.txt
@@ -30,7 +30,7 @@ method: {
     }
   }
   responses: {
-    key: "KOv-1LTHEKs="
+    key: "VHGmevV8BLM="
     value: {
       struct: {
         fields: {
@@ -40,6 +40,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_no_response_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_no_response_4xx_expected.pb.txt
@@ -1,5 +1,4 @@
 # api_spec.Witness proto
-
 method: {
   meta: {
     http: {
@@ -30,7 +29,7 @@ method: {
     }
   }
   responses: {
-    key: "ui5EpupUcWM="
+    key: "tZr-XY4VUbM="
     value: {
       struct: {
         fields: {
@@ -40,6 +39,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true

--- a/spec_util/testdata/meld/meld_no_response_4xx_non_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_no_response_4xx_non_4xx_expected.pb.txt
@@ -34,7 +34,7 @@ method: {
     }
   }
   responses: {
-    key: "oFUqCcv3wkM="
+    key: "kU5J_jopwLg="
     value: {
       struct: {
         fields: {
@@ -48,6 +48,7 @@ method: {
                 key: "ISOYearMonthDay"
                 value: true
               }
+              format_kind: "datetime"
             }
           }
         }
@@ -63,7 +64,7 @@ method: {
     }
   }
   responses: {
-    key: "ui5EpupUcWM="
+    key: "tZr-XY4VUbM="
     value: {
       struct: {
         fields: {
@@ -73,6 +74,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true

--- a/spec_util/testdata/meld/meld_non_4xx_with_4xx_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_non_4xx_with_4xx_expected.pb.txt
@@ -30,7 +30,7 @@ method: {
     }
   }
   responses: {
-    key: "ui5EpupUcWM="
+    key: "tZr-XY4VUbM="
     value: {
       struct: {
         fields: {
@@ -40,6 +40,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonthDay"
                 value: true
@@ -59,7 +60,7 @@ method: {
     }
   }
   responses: {
-    key: "naAThnYPT5A="
+    key: "FJkTUyXEoig="
     value: {
       struct: {
         fields: {
@@ -69,6 +70,7 @@ method: {
               string_value: {
                 value: "file_1"
               }
+              format_kind: "datetime"
               formats: {
                 key: "ISOYearMonth"
                 value: true

--- a/spec_util/testdata/meld/meld_oneof_with_oneof_1.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_oneof_1.pb.txt
@@ -2,7 +2,7 @@
 
 method: {
   responses: {
-    key:"xsMpke-69_I="
+    key:"6rjyoa2GEQI="
     value: {
       struct: {
         fields: {
@@ -10,7 +10,7 @@ method: {
           value: {
             oneof: {
               options: {
-                key: "VNe7F7DBhNg="
+                key: "UNaEMDveHLk="
                 value: {
                   struct: {
                     fields: {
@@ -18,6 +18,7 @@ method: {
                       value: {
                         primitive: {
                           string_value: {}
+                          format_kind: "datetime"
                           formats: {
                             key: "ISOYearMonth"
                             value: true

--- a/spec_util/testdata/meld/meld_oneof_with_oneof_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_oneof_expected.pb.txt
@@ -2,7 +2,7 @@
 
 method: {
   responses: {
-    key:"cyDYzRlAiDc="
+    key:"v1F5Arpo5g4="
     value: {
       struct: {
         fields: {
@@ -10,7 +10,7 @@ method: {
           value: {
             oneof: {
               options: {
-                key: "VNe7F7DBhNg="
+                key: "BC8hZFUbQsg="
                 value: {
                   struct: {
                     fields: {
@@ -18,10 +18,6 @@ method: {
                       value: {
                         primitive: {
                           string_value: {}
-                          formats: {
-                            key: "ISOYearMonth"
-                            value: true
-                          }
                         }
                       }
                     }


### PR DESCRIPTION
Right now, melding an int32 primitive with another int32 primitive with a data
format will result in a conflict.  However, this should simply result in int32.

The same is true for other base types, and also between different kinds of base
types.  As another example, melding int32 and uint32 should result in int64,
not a conflict.