### PR TITLE
Add support for contextless visitors

### DIFF
--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -486,6 +486,11 @@ func (*DefaultContextlessSpecVisitorImpl) NewContext() SpecVisitorContext {
 
 // extendContext implementation for SpecVisitor.
 func extendContext(cin Context, node interface{}) {
+	// Do nothing if using a dummy context.
+	if _, isDummy := cin.(*DummyVisitorContext); isDummy {
+		return
+	}
+
 	ctx, ok := cin.(SpecVisitorContext)
 	if !ok {
 		panic(fmt.Sprintf("http_rest.extendContext expected SpecVisitorContext, got %s",

--- a/visitors/http_rest/spec_visitor.go
+++ b/visitors/http_rest/spec_visitor.go
@@ -16,6 +16,11 @@ import (
 // VisitorManager that lets you read each message in an APISpec, starting with
 // the APISpec message itself.
 type SpecVisitor interface {
+	// Creates a new empty context for visiting an IR root. For visitors that
+	// do not care about context, NewDummyContext() is a good implementation.
+	// Otherwise, NewPreallocatedVisitorContext() is a good default.
+	NewContext() SpecVisitorContext
+
 	EnterAPISpec(self interface{}, ctxt SpecVisitorContext, node *pb.APISpec) Cont
 	VisitAPISpecChildren(self interface{}, ctxt SpecVisitorContext, vm VisitorManager, node *pb.APISpec) Cont
 	LeaveAPISpec(self interface{}, ctxt SpecVisitorContext, node *pb.APISpec, cont Cont) Cont
@@ -113,6 +118,10 @@ type DefaultSpecVisitor interface {
 type DefaultSpecVisitorImpl struct{}
 
 var _ SpecVisitor = (*DefaultSpecVisitorImpl)(nil)
+
+func (*DefaultSpecVisitorImpl) NewContext() SpecVisitorContext {
+	return NewPreallocatedVisitorContext()
+}
 
 func (*DefaultSpecVisitorImpl) EnterNode(self interface{}, ctxt SpecVisitorContext, node interface{}) Cont {
 	return Continue
@@ -463,6 +472,16 @@ func (*DefaultSpecVisitorImpl) VisitOneOfChildren(self interface{}, c SpecVisito
 
 func (*DefaultSpecVisitorImpl) LeaveOneOf(self interface{}, c SpecVisitorContext, d *pb.OneOf, cont Cont) Cont {
 	return self.(DefaultSpecVisitor).LeaveNode(self, c, d, cont)
+}
+
+type DefaultContextlessSpecVisitorImpl struct {
+	DefaultSpecVisitorImpl
+}
+
+var _ SpecVisitor = (*DefaultContextlessSpecVisitorImpl)(nil)
+
+func (*DefaultContextlessSpecVisitorImpl) NewContext() SpecVisitorContext {
+	return NewDummyVisitorContext()
 }
 
 // extendContext implementation for SpecVisitor.
@@ -818,7 +837,7 @@ func leave(cin Context, visitor interface{}, node interface{}, cont Cont) Cont {
 
 // Visits m with v.
 func Apply(v SpecVisitor, m interface{}) Cont {
-	c := NewPreallocatedVisitorContext()
+	c := v.NewContext()
 	vis := NewVisitorManager(c, v, enter, visitChildren, leave, extendContext)
 	return go_ast.Apply(vis, m)
 }

--- a/visitors/http_rest/spec_visitor_context.go
+++ b/visitors/http_rest/spec_visitor_context.go
@@ -540,3 +540,103 @@ func (c stackVisitorContext) setHttpAuthType(at pb.HTTPAuth_HTTPAuthType) {
 func (c stackVisitorContext) setTopLevelDataIndex(i int) {
 	c.Delegate().setTopLevelDataIndex(i)
 }
+
+type DummyVisitorContext struct{}
+
+var _ SpecVisitorContext = (*DummyVisitorContext)(nil)
+
+func NewDummyVisitorContext() *DummyVisitorContext {
+	return &DummyVisitorContext{}
+}
+
+func (c *DummyVisitorContext) EnterStruct(structNode interface{}, fieldName string) visitors.Context {
+	return c
+}
+
+func (c *DummyVisitorContext) EnterArray(arrayNode interface{}, elementIndex int) visitors.Context {
+	return c
+}
+
+func (c *DummyVisitorContext) EnterMapValue(mapNode, mapKey interface{}) visitors.Context {
+	return c
+}
+
+func (*DummyVisitorContext) GetPath() visitors.ContextPath {
+	return nil
+}
+
+func (c *DummyVisitorContext) GetOuter() visitors.Context {
+	return c
+}
+
+func (*DummyVisitorContext) GetFieldPath() []FieldPathElement {
+	return nil
+}
+
+func (*DummyVisitorContext) GetRestPath() []string {
+	return nil
+}
+
+func (*DummyVisitorContext) GetRestOperation() string {
+	return ""
+}
+
+func (*DummyVisitorContext) setRestOperation(string) {}
+
+func (*DummyVisitorContext) IsArg() bool {
+	return false
+}
+
+func (*DummyVisitorContext) IsResponse() bool {
+	return false
+}
+
+func (*DummyVisitorContext) IsOptional() bool {
+	return false
+}
+
+func (*DummyVisitorContext) GetValueType() HttpValueType {
+	return UNKNOWN
+}
+
+func (*DummyVisitorContext) GetHttpAuthType() *pb.HTTPAuth_HTTPAuthType {
+	return nil
+}
+
+func (*DummyVisitorContext) GetArgPath() []string {
+	return nil
+}
+
+func (*DummyVisitorContext) GetResponsePath() []string {
+	return nil
+}
+
+func (*DummyVisitorContext) GetEndpointPath() string {
+	return ""
+}
+
+func (*DummyVisitorContext) GetResponseCode() *string {
+	return nil
+}
+
+func (*DummyVisitorContext) GetContentType() *string {
+	return nil
+}
+
+func (*DummyVisitorContext) GetHost() string {
+	return ""
+}
+
+func (c *DummyVisitorContext) GetInnermostNode(reflect.Type) (interface{}, SpecVisitorContext) {
+	return nil, c
+}
+
+func (*DummyVisitorContext) appendFieldPath(FieldPathElement)         {}
+func (*DummyVisitorContext) appendRestPath(string)                    {}
+func (*DummyVisitorContext) setIsArg(bool)                            {}
+func (*DummyVisitorContext) setIsOptional()                           {}
+func (*DummyVisitorContext) setValueType(HttpValueType)               {}
+func (*DummyVisitorContext) setHttpAuthType(pb.HTTPAuth_HTTPAuthType) {}
+func (*DummyVisitorContext) setTopLevelDataIndex(int)                 {}
+func (*DummyVisitorContext) setResponseCode(string)                   {}
+func (*DummyVisitorContext) setContentType(string)                    {}

--- a/visitors/http_rest/spec_visitor_context.go
+++ b/visitors/http_rest/spec_visitor_context.go
@@ -562,81 +562,109 @@ func (c *DummyVisitorContext) EnterMapValue(mapNode, mapKey interface{}) visitor
 }
 
 func (*DummyVisitorContext) GetPath() visitors.ContextPath {
-	return nil
+	panic("Cannot call GetPath() on dummy context")
 }
 
-func (c *DummyVisitorContext) GetOuter() visitors.Context {
-	return c
+func (*DummyVisitorContext) GetOuter() visitors.Context {
+	panic("Cannot call GetOuter() on dummy context")
 }
 
 func (*DummyVisitorContext) GetFieldPath() []FieldPathElement {
-	return nil
+	panic("Cannot call GetFieldPath() on dummy context")
 }
 
 func (*DummyVisitorContext) GetRestPath() []string {
-	return nil
+	panic("Cannot call GetRestPath() on dummy context")
 }
 
 func (*DummyVisitorContext) GetRestOperation() string {
-	return ""
+	panic("Cannot call GetRestOperation() on dummy context")
 }
 
-func (*DummyVisitorContext) setRestOperation(string) {}
+func (*DummyVisitorContext) setRestOperation(string) {
+	panic("Cannot call setRestOperation() on dummy context")
+}
 
 func (*DummyVisitorContext) IsArg() bool {
-	return false
+	panic("Cannot call IsArg() on dummy context")
 }
 
 func (*DummyVisitorContext) IsResponse() bool {
-	return false
+	panic("Cannot call IsResponse() on dummy context")
 }
 
 func (*DummyVisitorContext) IsOptional() bool {
-	return false
+	panic("Cannot call IsOptional() on dummy context")
 }
 
 func (*DummyVisitorContext) GetValueType() HttpValueType {
-	return UNKNOWN
+	panic("Cannot call GetValueType() on dummy context")
 }
 
 func (*DummyVisitorContext) GetHttpAuthType() *pb.HTTPAuth_HTTPAuthType {
-	return nil
+	panic("Cannot call GetHttpAuthType() on dummy context")
 }
 
 func (*DummyVisitorContext) GetArgPath() []string {
-	return nil
+	panic("Cannot call GetArgPath() on dummy context")
 }
 
 func (*DummyVisitorContext) GetResponsePath() []string {
-	return nil
+	panic("Cannot call GetResponsePath() on dummy context")
 }
 
 func (*DummyVisitorContext) GetEndpointPath() string {
-	return ""
+	panic("Cannot call GetEndpointPath() on dummy context")
 }
 
 func (*DummyVisitorContext) GetResponseCode() *string {
-	return nil
+	panic("Cannot call GetResponseCode() on dummy context")
 }
 
 func (*DummyVisitorContext) GetContentType() *string {
-	return nil
+	panic("Cannot call GetContentType() on dummy context")
 }
 
 func (*DummyVisitorContext) GetHost() string {
-	return ""
+	panic("Cannot call GetHost() on dummy context")
 }
 
-func (c *DummyVisitorContext) GetInnermostNode(reflect.Type) (interface{}, SpecVisitorContext) {
-	return nil, c
+func (*DummyVisitorContext) GetInnermostNode(reflect.Type) (interface{}, SpecVisitorContext) {
+	panic("Cannot call GetInnermostNode() on dummy context")
 }
 
-func (*DummyVisitorContext) appendFieldPath(FieldPathElement)         {}
-func (*DummyVisitorContext) appendRestPath(string)                    {}
-func (*DummyVisitorContext) setIsArg(bool)                            {}
-func (*DummyVisitorContext) setIsOptional()                           {}
-func (*DummyVisitorContext) setValueType(HttpValueType)               {}
-func (*DummyVisitorContext) setHttpAuthType(pb.HTTPAuth_HTTPAuthType) {}
-func (*DummyVisitorContext) setTopLevelDataIndex(int)                 {}
-func (*DummyVisitorContext) setResponseCode(string)                   {}
-func (*DummyVisitorContext) setContentType(string)                    {}
+func (*DummyVisitorContext) appendFieldPath(FieldPathElement) {
+	panic("Cannot call appendFieldPath() on dummy context")
+}
+
+func (*DummyVisitorContext) appendRestPath(string) {
+	panic("Cannot call appendRestPath() on dummy context")
+}
+
+func (*DummyVisitorContext) setIsArg(bool) {
+	panic("Cannot call setIsArg() on dummy context")
+}
+
+func (*DummyVisitorContext) setIsOptional() {
+	panic("Cannot call setIsOptional() on dummy context")
+}
+
+func (*DummyVisitorContext) setValueType(HttpValueType) {
+	panic("Cannot call setValueType() on dummy context")
+}
+
+func (*DummyVisitorContext) setHttpAuthType(pb.HTTPAuth_HTTPAuthType) {
+	panic("Cannot call setHttpAuthType() on dummy context")
+}
+
+func (*DummyVisitorContext) setTopLevelDataIndex(int) {
+	panic("Cannot call setTopLevelDataIndex() on dummy context")
+}
+
+func (*DummyVisitorContext) setResponseCode(string) {
+	panic("Cannot call setResponseCode() on dummy context")
+}
+
+func (*DummyVisitorContext) setContentType(string) {
+	panic("Cannot call setContentType() on dummy context")
+}


### PR DESCRIPTION
Allows us to avoid the memory cost of maintaining contexts when they're not needed.