### PR TITLE
Track per-field and per-data format stats

### DIFF
--- a/spec_util/ir_hash/gen/gen.go
+++ b/spec_util/ir_hash/gen/gen.go
@@ -29,10 +29,11 @@ func main() {
 	gf.SetPackageName("ir_hash")
 	gf.AddImports()
 
+	gf.AddIgnoredField("Method", "Tracking")
 	gf.AddIgnoredField("HTTPMethodMeta", "ProcessingLatency")
 	gf.AddIgnoredField("Data", "ExampleValues")
+	gf.AddIgnoredField("Data", "Tracking")
 	gf.AddIgnoredField("Primitive", "CountByDataFormat")
-	gf.AddIgnoredField("Primitive", "Tracking")
 
 	// Newer protobuf compiler (1.39, v2 of go API) uses these instead of older XXX prefix (1.26, v1 of go API)
 	gf.AddIgnoredField("*", "state")

--- a/spec_util/ir_hash/gen/gen.go
+++ b/spec_util/ir_hash/gen/gen.go
@@ -31,6 +31,8 @@ func main() {
 
 	gf.AddIgnoredField("HTTPMethodMeta", "ProcessingLatency")
 	gf.AddIgnoredField("Data", "ExampleValues")
+	gf.AddIgnoredField("Primitive", "CountByDataFormat")
+	gf.AddIgnoredField("Primitive", "Tracking")
 
 	// Newer protobuf compiler (1.39, v2 of go API) uses these instead of older XXX prefix (1.26, v1 of go API)
 	gf.AddIgnoredField("*", "state")
@@ -177,6 +179,7 @@ func main() {
 		"witness.proto",
 		"types.proto",
 		"spec.proto",
+        "tracking.proto",
 	)
 
 	fset := token.NewFileSet()

--- a/spec_util/ir_hash/generated_types.go
+++ b/spec_util/ir_hash/generated_types.go
@@ -897,4 +897,4 @@ func HashWitness(node *pb.Witness) []byte {
 	return hash.Sum(nil)
 }
 
-var ProtobufFileHashes map[string][]byte = map[string][]byte{"method.proto": []byte{62, 32, 112, 208, 89, 253, 182, 74}, "witness.proto": []byte{42, 213, 185, 25, 124, 226, 76, 187}, "types.proto": []byte{98, 84, 34, 180, 249, 140, 214, 227}, "spec.proto": []byte{13, 101, 129, 126, 232, 252, 1, 146}, "tracking.proto": []byte{5, 250, 213, 81, 138, 111, 49, 193}}
+var ProtobufFileHashes map[string][]byte = map[string][]byte{"method.proto": []byte{186, 242, 215, 107, 45, 98, 26, 224}, "witness.proto": []byte{42, 213, 185, 25, 124, 226, 76, 187}, "types.proto": []byte{98, 84, 34, 180, 249, 140, 214, 227}, "spec.proto": []byte{13, 101, 129, 126, 232, 252, 1, 146}, "tracking.proto": []byte{164, 179, 140, 1, 86, 142, 46, 247}}

--- a/spec_util/ir_hash/generated_types.go
+++ b/spec_util/ir_hash/generated_types.go
@@ -897,4 +897,4 @@ func HashWitness(node *pb.Witness) []byte {
 	return hash.Sum(nil)
 }
 
-var ProtobufFileHashes map[string][]byte = map[string][]byte{"method.proto": []byte{69, 16, 236, 176, 97, 180, 164, 70}, "witness.proto": []byte{42, 213, 185, 25, 124, 226, 76, 187}, "types.proto": []byte{98, 84, 34, 180, 249, 140, 214, 227}, "spec.proto": []byte{13, 101, 129, 126, 232, 252, 1, 146}}
+var ProtobufFileHashes map[string][]byte = map[string][]byte{"method.proto": []byte{192, 113, 114, 9, 110, 171, 181, 15}, "witness.proto": []byte{42, 213, 185, 25, 124, 226, 76, 187}, "types.proto": []byte{98, 84, 34, 180, 249, 140, 214, 227}, "spec.proto": []byte{13, 101, 129, 126, 232, 252, 1, 146}, "tracking.proto": []byte{5, 250, 213, 81, 138, 111, 49, 193}}

--- a/spec_util/ir_hash/generated_types.go
+++ b/spec_util/ir_hash/generated_types.go
@@ -897,4 +897,4 @@ func HashWitness(node *pb.Witness) []byte {
 	return hash.Sum(nil)
 }
 
-var ProtobufFileHashes map[string][]byte = map[string][]byte{"method.proto": []byte{192, 113, 114, 9, 110, 171, 181, 15}, "witness.proto": []byte{42, 213, 185, 25, 124, 226, 76, 187}, "types.proto": []byte{98, 84, 34, 180, 249, 140, 214, 227}, "spec.proto": []byte{13, 101, 129, 126, 232, 252, 1, 146}, "tracking.proto": []byte{5, 250, 213, 81, 138, 111, 49, 193}}
+var ProtobufFileHashes map[string][]byte = map[string][]byte{"method.proto": []byte{62, 32, 112, 208, 89, 253, 182, 74}, "witness.proto": []byte{42, 213, 185, 25, 124, 226, 76, 187}, "types.proto": []byte{98, 84, 34, 180, 249, 140, 214, 227}, "spec.proto": []byte{13, 101, 129, 126, 232, 252, 1, 146}, "tracking.proto": []byte{5, 250, 213, 81, 138, 111, 49, 193}}

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -773,7 +773,21 @@ func meldAkitaWitnessTracking(dst, src *pb.AkitaWitnessTracking) {
 	}
 
 	// Update count.
-	dst.Count += src.Count
+	// Special case: a count of 1 is encoded as "0" to save space.  When
+	// reading the count, interpret 0 as 1.
+	{
+		dstCount := dst.Count
+		if dstCount == 0 {
+			dstCount = 1
+		}
+
+		srcCount := src.Count
+		if srcCount == 0 {
+			srcCount = 1
+		}
+
+		dst.Count = dstCount + srcCount
+	}
 
 	if dst.FirstSeen == nil {
 		dst.FirstSeen = src.FirstSeen

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -505,23 +505,23 @@ func TestMeldPrimitives(t *testing.T) {
 			left: &pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
 				CountByDataFormat: map[string]*pb.AkitaWitnessTracking{
-					"UUID":                     {Count: 1},
-					"InternationalPhoneNumber": {Count: 1},
+					"UUID":                     {Count: 0},
+					"InternationalPhoneNumber": {Count: 0},
 				},
 			},
 			right: &pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
 				CountByDataFormat: map[string]*pb.AkitaWitnessTracking{
-					"UUID":          {Count: 1},
-					"USPhoneNumber": {Count: 1},
+					"UUID":          {Count: 0},
+					"USPhoneNumber": {Count: 0},
 				},
 			},
 			expected: wrapPrim(&pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
 				CountByDataFormat: map[string]*pb.AkitaWitnessTracking{
 					"UUID":                     {Count: 2},
-					"InternationalPhoneNumber": {Count: 1},
-					"USPhoneNumber":            {Count: 1},
+					"InternationalPhoneNumber": {Count: 0},
+					"USPhoneNumber":            {Count: 0},
 				},
 			}),
 		},
@@ -588,58 +588,66 @@ func TestMeldData(t *testing.T) {
 		},
 		{
 			name: "merge sums liveness spans - left subsumes right",
-			left: wrapPrimWithTracking(&pb.Primitive{
-				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-			},
+			left: wrapPrimWithTracking(
+				&pb.Primitive{
+					Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
+				},
 				&pb.AkitaWitnessTracking{
-					FirstSeen: timestamppb.New(epoch),
-					LastSeenOffsetSeconds:  60 * 60 * 48,
+					FirstSeen:             timestamppb.New(epoch),
+					LastSeenOffsetSeconds: 60 * 60 * 48,
 				},
 			),
-			right: wrapPrimWithTracking(&pb.Primitive{
-				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-			},
+			right: wrapPrimWithTracking(
+				&pb.Primitive{
+					Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
+				},
 				&pb.AkitaWitnessTracking{
-					FirstSeen: timestamppb.New(epoch.Add(24 * time.Hour)),
-					LastSeenOffsetSeconds:  0,
+					FirstSeen:             timestamppb.New(epoch.Add(24 * time.Hour)),
+					LastSeenOffsetSeconds: 0,
 				},
 			),
-			expected: wrapPrimWithTracking(&pb.Primitive{
-				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-			},
+			expected: wrapPrimWithTracking(
+				&pb.Primitive{
+					Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
+				},
 				&pb.AkitaWitnessTracking{
-					FirstSeen: timestamppb.New(epoch),
-					LastSeenOffsetSeconds:  60 * 60 * 48 /* two days */,
+					FirstSeen:             timestamppb.New(epoch),
+					LastSeenOffsetSeconds: 60 * 60 * 48 /* two days */,
+					Count:                 2,
 				},
 			),
 		},
 		{
 			name: "merge sums liveness spans - left overlaps right",
-			left: wrapPrimWithTracking(&pb.Primitive{
-				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-			},
+			left: wrapPrimWithTracking(
+				&pb.Primitive{
+					Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
+				},
 				// [epoch + 1, epoch + 3]
 				&pb.AkitaWitnessTracking{
-					FirstSeen: timestamppb.New(epoch.Add(24 * time.Hour)),
-					LastSeenOffsetSeconds:  60 * 60 * 48 /* 2 days */,
+					FirstSeen:             timestamppb.New(epoch.Add(24 * time.Hour)),
+					LastSeenOffsetSeconds: 60 * 60 * 48 /* 2 days */,
 				},
 			),
-			right: wrapPrimWithTracking(&pb.Primitive{
-				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-			},
+			right: wrapPrimWithTracking(
+				&pb.Primitive{
+					Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
+				},
 				// [epoch, epoch + 2]
 				&pb.AkitaWitnessTracking{
-					FirstSeen: timestamppb.New(epoch),
-					LastSeenOffsetSeconds:  60 * 60 * 48 /* 2 days */,
+					FirstSeen:             timestamppb.New(epoch),
+					LastSeenOffsetSeconds: 60 * 60 * 48 /* 2 days */,
 				},
 			),
-			expected: wrapPrimWithTracking(&pb.Primitive{
-				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-			},
+			expected: wrapPrimWithTracking(
+				&pb.Primitive{
+					Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
+				},
 				// [epoch, epoch + 3]
 				&pb.AkitaWitnessTracking{
-					FirstSeen: timestamppb.New(epoch),
-					LastSeenOffsetSeconds:  60 * 60 * 72 /* 3 days */,
+					FirstSeen:             timestamppb.New(epoch),
+					LastSeenOffsetSeconds: 60 * 60 * 72 /* 3 days */,
+					Count:                 2,
 				},
 			),
 		},
@@ -648,12 +656,12 @@ func TestMeldData(t *testing.T) {
 			left: wrapPrimWithTracking(&pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
 			},
-				&pb.AkitaWitnessTracking{Count: 1},
+				&pb.AkitaWitnessTracking{Count: 0},
 			),
 			right: wrapPrimWithTracking(&pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
 			},
-				&pb.AkitaWitnessTracking{Count: 1},
+				&pb.AkitaWitnessTracking{Count: 0},
 			),
 			expected: wrapPrimWithTracking(&pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -515,24 +515,24 @@ func TestMeldPrimitives(t *testing.T) {
 			name: "merge sums counts by data format",
 			left: &pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-				CountByDataFormat: map[string]int64{
-					"UUID": 1,
-					"InternationalPhoneNumber": 1,
+				CountByDataFormat: map[string]*pb.AkitaWitnessTracking{
+					"UUID": {Count: 1},
+					"InternationalPhoneNumber": {Count: 1},
 				},
 			},
 			right: &pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-				CountByDataFormat: map[string]int64{
-					"UUID": 1,
-					"USPhoneNumber": 1,
+				CountByDataFormat: map[string]*pb.AkitaWitnessTracking{
+					"UUID": {Count: 1},
+					"USPhoneNumber": {Count: 1},
 				},
 			},
 			expected: wrapPrim(&pb.Primitive{
 				Value: &pb.Primitive_Int32Value{Int32Value: &pb.Int32{}},
-				CountByDataFormat: map[string]int64{
-					"UUID": 2,
-					"InternationalPhoneNumber": 1,
-					"USPhoneNumber": 1,
+				CountByDataFormat: map[string]*pb.AkitaWitnessTracking{
+					"UUID": {Count: 2},
+					"InternationalPhoneNumber": {Count: 1},
+					"USPhoneNumber": {Count: 1},
 				},
 			}),
 		},

--- a/spec_util/melded_method.go
+++ b/spec_util/melded_method.go
@@ -104,6 +104,9 @@ func (dst *meldedMethod) Meld(src MeldedMethod) error {
 		return errors.Wrap(err, "failed to meld response map")
 	}
 
+	// Update witness tracking.
+	meldAkitaWitnessTracking(dst.method.Tracking, src.GetMethod().Tracking)
+
 	return nil
 }
 


### PR DESCRIPTION
Depends on https://github.com/akitasoftware/akita-ir/pull/8.

1. Updates `spec_util.ir_hash` to ignore tracking data in the IR when hashing.
2. Updates `MeldMethod` and `MeldData` to merge tracking data.