### PR TITLE
Improve path parameter annotations

### DIFF
--- a/path_pattern/components.go
+++ b/path_pattern/components.go
@@ -1,7 +1,7 @@
 package path_pattern
 
 import (
-	"strings"
+	"regexp"
 )
 
 // Represents a path component value, which can be either a concrete string Val
@@ -23,17 +23,7 @@ func (v Val) String() string {
 }
 
 func (v Val) Regexp() string {
-	return "(" + escape(v.String()) + ")"
-}
-
-// Escapes special regexp characters in s.
-func escape(s string) string {
-	specialChars := []string{"\\",".","+","*","?","(",")","|","[","]","{","}","^","$"}
-	rv := s
-	for _, c := range specialChars {
-		rv = strings.ReplaceAll(rv, c, "\\" + c)
-	}
-	return rv
+	return "(" + regexp.QuoteMeta(v.String()) + ")"
 }
 
 type Var string

--- a/path_pattern/components.go
+++ b/path_pattern/components.go
@@ -9,6 +9,8 @@ import (
 type Component interface {
 	Match(string) bool
 	String() string
+
+	// Returns a parenthesized regular expression for this component.
 	Regexp() string
 }
 

--- a/path_pattern/pattern_test.go
+++ b/path_pattern/pattern_test.go
@@ -11,16 +11,18 @@ import (
 func TestParse(t *testing.T) {
 	testCases := []struct {
 		input    string
-		expected Pattern
+		expected *patternImpl
 	}{
 		{
 			input: "/v1//foobar/{foobar}/",
-			expected: Pattern{
-				Val(""),
-				Val("v1"),
-				Val(""),
-				Val("foobar"),
-				Var("foobar"),
+			expected: &patternImpl{
+				components: []Component{
+					Val(""),
+					Val("v1"),
+					Val(""),
+					Val("foobar"),
+					Var("foobar"),
+				},
 			},
 		},
 	}
@@ -36,23 +38,27 @@ func TestParse(t *testing.T) {
 func TestParseAndString(t *testing.T) {
 	testCases := []struct {
 		input    string
-		expected Pattern
+		expected *patternImpl
 	}{
 		{
 			input: "/v1/{my_arg_name}",
-			expected: Pattern{
-				Val(""),
-				Val("v1"),
-				Var("my_arg_name"),
+			expected: &patternImpl{
+				components: []Component{
+					Val(""),
+					Val("v1"),
+					Var("my_arg_name"),
+				},
 			},
 		},
 		{
 			input: "/v1/*/foobar",
-			expected: Pattern{
-				Val(""),
-				Val("v1"),
-				Wildcard{},
-				Val("foobar"),
+			expected: &patternImpl{
+				components: []Component{
+					Val(""),
+					Val("v1"),
+					Wildcard{},
+					Val("foobar"),
+				},
 			},
 		},
 	}

--- a/path_pattern/pattern_test.go
+++ b/path_pattern/pattern_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// For patterns with trailing slashes, for which serialization/deserialization
+// is not idempotent.
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected Pattern
+	}{
+		{
+			input: "/v1//foobar/{foobar}/",
+			expected: Pattern{
+				Val(""),
+				Val("v1"),
+				Val(""),
+				Val("foobar"),
+				Var("foobar"),
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		p := Parse(c.input)
+		assert.Equal(t, c.expected, p, c.input)
+	}
+}
+
+// For patterns without trailing slashes.  Also tests that parsing and then
+// serializing the pattern returns the original string.
 func TestParseAndString(t *testing.T) {
 	testCases := []struct {
 		input    string
@@ -17,26 +44,6 @@ func TestParseAndString(t *testing.T) {
 				Val(""),
 				Val("v1"),
 				Var("my_arg_name"),
-			},
-		},
-		{
-			input: "/v1//foobar/{foobar}/",
-			expected: Pattern{
-				Val(""),
-				Val("v1"),
-				Val(""),
-				Val("foobar"),
-				Var("foobar"),
-				Val(""),
-			},
-		},
-		{
-			input: "/v1/^/foobar",
-			expected: Pattern{
-				Val(""),
-				Val("v1"),
-				Placeholder{},
-				Val("foobar"),
 			},
 		},
 		{
@@ -71,11 +78,16 @@ func TestMatch(t *testing.T) {
 		{
 			pattern:     "/v1/{my_arg_name}",
 			target:      "/v1/foobar/x",
-			expectMatch: true,
+			expectMatch: false,
 		},
 		{
 			pattern:     "/v1/{my_arg_name}",
 			target:      "/v1/foobar/",
+			expectMatch: true,
+		},
+		{
+			pattern:     "/v1/{my_arg_name}/",
+			target:      "/v1/foobar",
 			expectMatch: true,
 		},
 		{
@@ -96,7 +108,7 @@ func TestMatch(t *testing.T) {
 		{
 			pattern:     "/v1/^/{my_arg_name}",
 			target:      "/v1/foo/bar",
-			expectMatch: true,
+			expectMatch: false,
 		},
 		{
 			pattern:     "/v1/{my_arg_name}",
@@ -113,6 +125,31 @@ func TestMatch(t *testing.T) {
 			// Target does not have enough components to match.
 			pattern:     "/v1/{my_arg_name}",
 			target:      "/v1",
+			expectMatch: false,
+		},
+		{
+			pattern:     "/v1/**",
+			target:      "/v1/foo/bar/baz",
+			expectMatch: true,
+		},
+		{
+			pattern:     "/v1/**/baz",
+			target:      "/v1/foo/bar/baz",
+			expectMatch: true,
+		},
+		{
+			pattern:     "/v1/**/baz/bar",
+			target:      "/v1/foo/bar/baz",
+			expectMatch: false,
+		},
+		{
+			pattern:     "/v1/foo/;|{}/bar",
+			target:      "/v1/foo/bar/baz",
+			expectMatch: false,
+		},
+		{
+			pattern:     "/v1/foo/b.r/baz",
+			target:      "/v1/foo/bar/baz",
 			expectMatch: false,
 		},
 	}


### PR DESCRIPTION
Path parameter annotations used to include special symbols `{arg}`, `*`
(wildcard), and `^` (prevent path parameter at this position), and they used to
match by longest prefix.

This PR makes two syntax changes:
 - removes `^` (it was never used in practice)
 - adds `**` (like `*`, but matches zero or more path segments)

It also makes several changes to the matching semantics:
 - annotations are now exact match rather than prefix match (prefix match is
   recoverable using `**`)
 - matches ignore trailing slashes
