### PR TITLE
Add path parameter placeholders

### DIFF
--- a/path_pattern/components.go
+++ b/path_pattern/components.go
@@ -81,3 +81,21 @@ func (DoubleWildcard) String() string {
 func (v DoubleWildcard) Regexp() string {
 	return "(.*)"
 }
+
+// A component that should retain the original value verbatim, otherwise behaves
+// like a wildcard.  Matches everything except path parameters.
+type Placeholder struct{}
+
+var _ Component = (*Placeholder)(nil)
+
+func (Placeholder) Match(c string) bool {
+	return true
+}
+
+func (Placeholder) String() string {
+	return "^"
+}
+
+func (Placeholder) Regexp() string {
+	return "([^{}/]+)"
+}

--- a/path_pattern/pattern.go
+++ b/path_pattern/pattern.go
@@ -88,6 +88,8 @@ func Parse(v string) Pattern {
 			result.components = append(result.components, Wildcard{})
 		} else if p == "**" {
 			result.components = append(result.components, DoubleWildcard{})
+		} else if p == "^" {
+			result.components = append(result.components, Placeholder{})
 		} else if strings.HasPrefix(p, "{") && strings.HasSuffix(p, "}") {
 			result.components = append(result.components, Var(p[1:len(p)-1]))
 		} else {

--- a/path_pattern/pattern_test.go
+++ b/path_pattern/pattern_test.go
@@ -128,7 +128,7 @@ func TestMatch(t *testing.T) {
 		{
 			pattern:     "/v1/^/{my_arg_name}",
 			target:      "/v1/foo/bar",
-			expectMatch: false,
+			expectMatch: true,
 		},
 		{
 			pattern:     "/v1/{my_arg_name}",
@@ -170,6 +170,31 @@ func TestMatch(t *testing.T) {
 		{
 			pattern:     "/v1/foo/b.r/baz",
 			target:      "/v1/foo/bar/baz",
+			expectMatch: false,
+		},
+		{
+			pattern:     "/^",
+			target:      "/v1",
+			expectMatch: true,
+		},
+		{
+			pattern:     "/v1/^",
+			target:      "/v1/foo",
+			expectMatch: true,
+		},
+		{
+			pattern:     "/v1/^/bar",
+			target:      "/v1/foo/bar",
+			expectMatch: true,
+		},
+		{
+			pattern:     "/v1/^",
+			target:      "/v1/{arg}",
+			expectMatch: false,
+		},
+		{
+			pattern:     "/v1/^/bar",
+			target:      "/v1/{arg}/bar",
 			expectMatch: false,
 		},
 	}


### PR DESCRIPTION
Placeholders are like wildcards, but they indicate that the matching path
component should not be collapsed into a path parameter.