### PR TITLE
Support tag multisets for tagging specs with versions

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -255,7 +255,7 @@ type GetSpecMetadataResponse struct {
 
 	State APISpecState `json:"state"`
 
-	Tags map[tags.Key]string `json:"tags"`
+	Tags map[tags.Key][]string `json:"tags"`
 }
 
 type GetSpecResponse struct {
@@ -276,7 +276,7 @@ type GetSpecResponse struct {
 
 	Summary *spec_summary.Summary `json:"summary,omitempty"`
 
-	Tags map[tags.Key]string `json:"tags"`
+	Tags map[tags.Key][]string `json:"tags"`
 }
 
 type SetSpecVersionRequest struct {
@@ -302,8 +302,8 @@ type SpecInfo struct {
 	// Use Tags field instead.
 	LearnSessionTags []LearnSessionTag `json:"learn_session_tags,omitempty"`
 
-	Tags        map[tags.Key]string `json:"tags,omitempty"`
-	VersionTags []string            `json:"version_tags,omitempty"`
+	Tags        map[tags.Key][]string `json:"tags,omitempty"`
+	VersionTags []string              `json:"version_tags,omitempty"`
 
 	CreationTime time.Time    `json:"creation_time"`
 	EditTime     time.Time    `json:"edit_time"`

--- a/tags/reserved_tags.go
+++ b/tags/reserved_tags.go
@@ -16,6 +16,10 @@ const (
 
 	// The original filesystem path of an uploaded trace.
 	XAkitaTraceLocalPath Key = "x-akita-trace-local-path"
+
+	// The version of the service(s) under observation, as defined by the
+	// user.
+	XAkitaServiceVersion Key = "x-akita-service-version"
 )
 
 // Generic CI tags

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -8,13 +8,36 @@ import (
 )
 
 type Key = tags.Key
+type Values = []string
 
-// Returns a map from parsing a list of "key=value" pairs.
+// FromPairs returns a map from parsing a list of "key=value" pairs.
 // Produces an error if any element of the list is improperly formatted,
 // or if any key is given more than once.
 // The caller must emit an appropriate warning if any keys are reserved.
 func FromPairs(pairs []string) (map[Key]string, error) {
-	results := make(map[Key]string, len(pairs))
+	multiset, err := FromPairsMultiset(pairs)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[Key]string, len(multiset))
+	for k, vs := range multiset {
+		if len(vs) > 1 {
+			return nil, errors.Errorf("tag with key %s specified more than once", k)
+		}
+		for _, v := range vs {
+			results[k] = v
+		}
+	}
+
+	return results, nil
+}
+
+// FromPairsMultiset returns a map from parsing a list of "key=value" pairs.
+// Produces an error if any element of the list is improperly formatted.
+// The caller must emit an appropriate warning if any keys are reserved.
+func FromPairsMultiset(pairs []string) (map[Key]Values, error) {
+	results := make(map[Key]Values, len(pairs))
 	for _, p := range pairs {
 		parts := strings.Split(p, "=")
 		if len(parts) != 2 {
@@ -22,11 +45,7 @@ func FromPairs(pairs []string) (map[Key]string, error) {
 		}
 
 		k, v := Key(parts[0]), parts[1]
-		if _, ok := results[k]; ok {
-			return nil, errors.Errorf("tag with key %s specified more than once", k)
-		}
-
-		results[k] = v
+		results[k] = append(results[k], v)
 	}
 	return results, nil
 }


### PR DESCRIPTION
This PR extends tags to support multiple values per tag.  APIs will still
reject requests with tag multisets, but responses may now contain tag
multisets.