### PR TITLE
Make tag multisets backwards compatible

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -255,10 +255,10 @@ type GetSpecMetadataResponse struct {
 
 	State APISpecState `json:"state"`
 
-	// Deprecated in favor of TagsMultiset, which supports multiple values
+	// Deprecated in favor of TagsSet, which supports multiple values
 	// per tag.
-	Tags         tags.SingletonTags `json:"tags,omitempty"`
-	TagsMultiset tags.Tags          `json:"tags_multiset,omitempty"`
+	Tags    tags.SingletonTags `json:"tags,omitempty"`
+	TagsSet tags.Tags          `json:"tags_set,omitempty"`
 }
 
 type GetSpecResponse struct {
@@ -279,10 +279,10 @@ type GetSpecResponse struct {
 
 	Summary *spec_summary.Summary `json:"summary,omitempty"`
 
-	// Deprecated in favor of TagsMultiset, which supports multiple values
+	// Deprecated in favor of TagsSet, which supports multiple values
 	// per tag.
-	Tags         tags.SingletonTags `json:"tags,omitempty"`
-	TagsMultiset tags.Tags          `json:"tags_multiset,omitempty"`
+	Tags    tags.SingletonTags `json:"tags,omitempty"`
+	TagsSet tags.Tags          `json:"tags_set,omitempty"`
 }
 
 type SetSpecVersionRequest struct {
@@ -308,10 +308,10 @@ type SpecInfo struct {
 	// Use Tags field instead.
 	LearnSessionTags []LearnSessionTag `json:"learn_session_tags,omitempty"`
 
-	// Deprecated in favor of TagsMultiset, which supports multiple values
+	// Deprecated in favor of TagsSet, which supports multiple values
 	// per tag.
-	Tags         tags.SingletonTags `json:"tags,omitempty"`
-	TagsMultiset tags.Tags          `json:"tags_multiset,omitempty"`
+	Tags    tags.SingletonTags `json:"tags,omitempty"`
+	TagsSet tags.Tags          `json:"tags_set,omitempty"`
 
 	VersionTags []string `json:"version_tags,omitempty"`
 

--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -68,7 +68,7 @@ type CreateLearnSessionRequest struct {
 
 	// Optional key-value pairs to tag this learn session.
 	// We reserve tags with "x-akita-" prefix for internal use.
-	Tags map[tags.Key]string `json:"tags,omitempty"`
+	Tags tags.SingletonTags `json:"tags,omitempty"`
 
 	// Optional name for the learn session.
 	Name string `json:"name"`
@@ -193,7 +193,7 @@ type CreateSpecRequest struct {
 	Name string `json:"name"`
 
 	// Optional: user-specified tags.
-	Tags map[tags.Key]string `json:"tags"`
+	Tags tags.SingletonTags `json:"tags"`
 }
 
 type CreateTimeSpanSpecRequest struct {
@@ -202,8 +202,8 @@ type CreateTimeSpanSpecRequest struct {
 }
 
 type UploadSpecRequest struct {
-	Name string              `json:"name"`
-	Tags map[tags.Key]string `json:"tags,omitempty"`
+	Name string             `json:"name"`
+	Tags tags.SingletonTags `json:"tags,omitempty"`
 
 	// TODO(kku): use multipart/form-data upload once we can support it.
 	Content string `json:"content"`
@@ -239,8 +239,8 @@ type WitnessReport struct {
 	// A serialized Witness protobuf in base64 URL encoded format.
 	WitnessProto string `json:"witness_proto"`
 
-	ID   akid.WitnessID      `json:"id"`
-	Tags map[tags.Key]string `json:"tags"`
+	ID   akid.WitnessID     `json:"id"`
+	Tags tags.SingletonTags `json:"tags"`
 
 	// Hash of the witness proto. Only used internally in the client.
 	Hash string `json:"-"`
@@ -255,7 +255,10 @@ type GetSpecMetadataResponse struct {
 
 	State APISpecState `json:"state"`
 
-	Tags map[tags.Key][]string `json:"tags"`
+	// Deprecated in favor of TagsMultiset, which supports multiple values
+	// per tag.
+	Tags         tags.SingletonTags `json:"tags,omitempty"`
+	TagsMultiset tags.Tags          `json:"tags_multiset,omitempty"`
 }
 
 type GetSpecResponse struct {
@@ -276,7 +279,10 @@ type GetSpecResponse struct {
 
 	Summary *spec_summary.Summary `json:"summary,omitempty"`
 
-	Tags map[tags.Key][]string `json:"tags"`
+	// Deprecated in favor of TagsMultiset, which supports multiple values
+	// per tag.
+	Tags         tags.SingletonTags `json:"tags,omitempty"`
+	TagsMultiset tags.Tags          `json:"tags_multiset,omitempty"`
 }
 
 type SetSpecVersionRequest struct {
@@ -302,8 +308,12 @@ type SpecInfo struct {
 	// Use Tags field instead.
 	LearnSessionTags []LearnSessionTag `json:"learn_session_tags,omitempty"`
 
-	Tags        map[tags.Key][]string `json:"tags,omitempty"`
-	VersionTags []string              `json:"version_tags,omitempty"`
+	// Deprecated in favor of TagsMultiset, which supports multiple values
+	// per tag.
+	Tags         tags.SingletonTags `json:"tags,omitempty"`
+	TagsMultiset tags.Tags          `json:"tags_multiset,omitempty"`
+
+	VersionTags []string `json:"version_tags,omitempty"`
 
 	CreationTime time.Time    `json:"creation_time"`
 	EditTime     time.Time    `json:"edit_time"`

--- a/tags/singleton_tags.go
+++ b/tags/singleton_tags.go
@@ -1,0 +1,38 @@
+package tags
+
+import "github.com/pkg/errors"
+
+// SingletonTags maps tags to single values.
+type SingletonTags map[Key]string
+
+func (ts SingletonTags) AsTags() Tags {
+	tags := make(Tags, len(ts))
+	for t, v := range ts {
+		tags.SetSingleton(t, v)
+	}
+	return tags
+}
+
+// FromPairsSingleton returns a map from parsing a list of "key=value" pairs.
+// Produces an error if any element of the list is improperly formatted,
+// or if any key is given more than once.
+// The caller must emit an appropriate warning if any keys are reserved.
+func FromPairs(pairs []string) (SingletonTags, error) {
+	tags, err := FromPairsMultivalue(pairs)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(SingletonTags, len(tags))
+	for k, vs := range tags {
+		vSlice := vs.AsSlice()
+		if len(vSlice) == 0 {
+			continue
+		} else if len(vSlice) > 1 {
+			return nil, errors.Errorf("tag with key %s specified more than once", k)
+		}
+		results[k] = vSlice[0]
+	}
+
+	return results, nil
+}

--- a/tags/singleton_tags.go
+++ b/tags/singleton_tags.go
@@ -13,7 +13,7 @@ func (ts SingletonTags) AsTags() Tags {
 	return tags
 }
 
-// FromPairsSingleton returns a map from parsing a list of "key=value" pairs.
+// Returns a SingletonTags from parsing a list of "key=value" pairs.
 // Produces an error if any element of the list is improperly formatted,
 // or if any key is given more than once.
 // The caller must emit an appropriate warning if any keys are reserved.

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -8,19 +8,20 @@ import (
 )
 
 type Key = tags.Key
-type Values = []string
+type Tags map[Key][]string
+type SingletonTags map[Key]string
 
-// FromPairs returns a map from parsing a list of "key=value" pairs.
+// Returns a map from parsing a list of "key=value" pairs.
 // Produces an error if any element of the list is improperly formatted,
 // or if any key is given more than once.
 // The caller must emit an appropriate warning if any keys are reserved.
-func FromPairs(pairs []string) (map[Key]string, error) {
+func FromPairs(pairs []string) (SingletonTags, error) {
 	multiset, err := FromPairsMultiset(pairs)
 	if err != nil {
 		return nil, err
 	}
 
-	results := make(map[Key]string, len(multiset))
+	results := make(SingletonTags, len(multiset))
 	for k, vs := range multiset {
 		if len(vs) > 1 {
 			return nil, errors.Errorf("tag with key %s specified more than once", k)
@@ -36,8 +37,8 @@ func FromPairs(pairs []string) (map[Key]string, error) {
 // FromPairsMultiset returns a map from parsing a list of "key=value" pairs.
 // Produces an error if any element of the list is improperly formatted.
 // The caller must emit an appropriate warning if any keys are reserved.
-func FromPairsMultiset(pairs []string) (map[Key]Values, error) {
-	results := make(map[Key]Values, len(pairs))
+func FromPairsMultiset(pairs []string) (Tags, error) {
+	results := make(Tags, len(pairs))
 	for _, p := range pairs {
 		parts := strings.Split(p, "=")
 		if len(parts) != 2 {

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -8,36 +8,93 @@ import (
 )
 
 type Key = tags.Key
-type Tags map[Key][]string
-type SingletonTags map[Key]string
+type Value = string
 
-// Returns a map from parsing a list of "key=value" pairs.
-// Produces an error if any element of the list is improperly formatted,
-// or if any key is given more than once.
-// The caller must emit an appropriate warning if any keys are reserved.
-func FromPairs(pairs []string) (SingletonTags, error) {
-	multiset, err := FromPairsMultiset(pairs)
-	if err != nil {
-		return nil, err
-	}
+// Maps tags to sets of values.
+type Tags map[Key]ValueSet
 
-	results := make(SingletonTags, len(multiset))
-	for k, vs := range multiset {
-		if len(vs) > 1 {
-			return nil, errors.Errorf("tag with key %s specified more than once", k)
-		}
-		for _, v := range vs {
-			results[k] = v
-		}
-	}
-
-	return results, nil
+// Sets the given key to the given values.  Values are copied.
+func (t Tags) Set(key tags.Key, values []string) {
+	t[key] = NewValueSet(values...)
 }
 
-// FromPairsMultiset returns a map from parsing a list of "key=value" pairs.
+// Sets the given key to the given value.
+func (t Tags) SetSingleton(key tags.Key, value string) {
+	t.Set(key, []Value{value})
+}
+
+// Adds a value to the given key.
+func (t Tags) Add(key tags.Key, value string) {
+	t[key].Add(value)
+}
+
+// SetAll copies all values from t2 into t. If a key exists in both sets of tags, the
+// value in t is overwritten with that in t2.
+func (t Tags) SetAll(t2 Tags) {
+	for key, values := range t2 {
+		t.Set(key, values.AsSlice())
+	}
+}
+
+// Removes any tag from t that doesn't exist in t2.  For any key k in both t
+// and t2, t[k] is remapped to the intersection of their values.
+func (t Tags) Intersect(t2 Tags) {
+	for key, values := range t {
+		otherValues, ok := t2[key]
+
+		// Remove keys not in t2.
+		if !ok {
+			delete(t, key)
+		}
+
+		// Remove values not in t2.
+		values.Intersect(otherValues)
+
+		// If there are no values remaining, remove the tag.
+		if len(values) == 0 {
+			delete(t, key)
+		}
+	}
+}
+
+// Copies tags from t2 that don't exist in t.  For any key k in both t and t2,
+// t[k] is remapped to the union of their values.  Does not preserve duplicates
+// or maintain list order.
+func (t Tags) Union(t2 Tags) {
+	for otherTag, otherValues := range t2 {
+		if values, exists := t[otherTag]; !exists {
+			t[otherTag] = otherValues.Clone()
+		} else {
+			values.AddAll(otherValues)
+		}
+	}
+}
+
+func (t Tags) Clone() Tags {
+	rv := make(Tags, len(t))
+	for t, vs := range t {
+		rv[t] = vs.Clone()
+	}
+	return rv
+}
+
+// Returns a new tags map with a single value for each tag.  If more than one
+// value was present for a given tag, returns the first value in the list.
+// If there are no values in the list, the tag is removed.
+func (t Tags) AsSingletonTags() SingletonTags {
+	rv := make(SingletonTags, len(t))
+	for tag, values := range t {
+		if v, exists := values.GetFirst(); exists {
+			rv[tag] = v
+		}
+	}
+	return rv
+}
+
+// FromPairs returns a map from parsing a list of "key=value" pairs.
 // Produces an error if any element of the list is improperly formatted.
 // The caller must emit an appropriate warning if any keys are reserved.
-func FromPairsMultiset(pairs []string) (Tags, error) {
+func FromPairsMultivalue(pairs []string) (Tags, error) {
 	results := make(Tags, len(pairs))
 	for _, p := range pairs {
 		parts := strings.Split(p, "=")
@@ -46,7 +103,7 @@ func FromPairsMultiset(pairs []string) (Tags, error) {
 		}
 
 		k, v := Key(parts[0]), parts[1]
-		results[k] = append(results[k], v)
+		results.Add(k, v)
 	}
 	return results, nil
 }

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -20,7 +20,7 @@ func (t Tags) Set(key tags.Key, values []string) {
 
 // Sets the given key to the given value.
 func (t Tags) SetSingleton(key tags.Key, value string) {
-	t.Set(key, []Value{value})
+	t[key] = NewValueSet(value)
 }
 
 // Adds a value to the given key.
@@ -37,7 +37,8 @@ func (t Tags) SetAll(t2 Tags) {
 }
 
 // Removes any tag from t that doesn't exist in t2.  For any key k in both t
-// and t2, t[k] is remapped to the intersection of their values.
+// and t2, t[k] is remapped to the intersection of their values.  If the
+// intersection is empty, then k is removed.
 func (t Tags) Intersect(t2 Tags) {
 	for key, values := range t {
 		otherValues, ok := t2[key]
@@ -65,7 +66,7 @@ func (t Tags) Union(t2 Tags) {
 		if values, exists := t[otherTag]; !exists {
 			t[otherTag] = otherValues.Clone()
 		} else {
-			values.AddAll(otherValues)
+			values.Union(otherValues)
 		}
 	}
 }
@@ -91,7 +92,7 @@ func (t Tags) AsSingletonTags() SingletonTags {
 	return rv
 }
 
-// FromPairs returns a map from parsing a list of "key=value" pairs.
+// Returns a Tags from parsing a list of "key=value" pairs.
 // Produces an error if any element of the list is improperly formatted.
 // The caller must emit an appropriate warning if any keys are reserved.
 func FromPairsMultivalue(pairs []string) (Tags, error) {

--- a/tags/tags_test.go
+++ b/tags/tags_test.go
@@ -1,0 +1,173 @@
+package tags
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSet(t *testing.T) {
+	tagMap := Tags{}
+	assert.Equal(t, Tags{}, tagMap, "empty tags maps are equivalent")
+
+	tagMap.Set("key", []string{"v1", "v2"})
+	assert.Equal(t, Tags{"key": NewValueSet("v1", "v2")}, tagMap, "insert two values")
+}
+
+func TestTagsUnion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		left     Tags
+		right    Tags
+		expected Tags
+	}{
+		{
+			name: "union lists with duplicates",
+			left: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v1"),
+			},
+			right: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v2", "v2"),
+			},
+			expected: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v2"),
+			},
+		},
+		{
+			name:     "empty tags remain empty",
+			left:     Tags{},
+			right:    Tags{},
+			expected: Tags{},
+		},
+		{
+			name: "empty list is idempotent",
+			left: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v2"),
+			},
+			right: Tags{
+				XAkitaServiceVersion: NewValueSet(),
+			},
+			expected: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v2"),
+			},
+		},
+		{
+			name: "missing tag is idempotent",
+			left: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v2"),
+			},
+			right: Tags{},
+			expected: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v2"),
+			},
+		},
+		{
+			name: "union no duplicates",
+			left: Tags{
+				XAkitaServiceVersion: NewValueSet("v1"),
+			},
+			right: Tags{
+				XAkitaServiceVersion: NewValueSet("v1"),
+			},
+			expected: Tags{
+				XAkitaServiceVersion: NewValueSet("v1"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		left := tc.left.Clone()
+		left.Union(tc.right)
+		assert.Equal(t, tc.expected, left, "[left]"+tc.name)
+
+		right := tc.right.Clone()
+		right.Union(tc.left)
+		assert.Equal(t, tc.expected, right, "[right] "+tc.name)
+	}
+}
+
+func TestTagsIntersect(t *testing.T) {
+	testCases := []struct {
+		name     string
+		left     Tags
+		right    Tags
+		expected Tags
+	}{
+		{
+			name: "intersect lists with duplicates",
+			left: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v1", "v2"),
+			},
+			right: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v1", "v1"),
+			},
+			expected: Tags{
+				XAkitaServiceVersion: NewValueSet("v1"),
+			},
+		},
+		{
+			name:     "empty tags remain empty",
+			left:     Tags{},
+			right:    Tags{},
+			expected: Tags{},
+		},
+		{
+			name: "empty list is an annihilator",
+			left: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v1", "v2"),
+			},
+			right: Tags{
+				XAkitaServiceVersion: NewValueSet(),
+			},
+			expected: Tags{},
+		},
+		{
+			name: "missing tag is an annihilator",
+			left: Tags{
+				XAkitaServiceVersion: NewValueSet("v1", "v1", "v2"),
+			},
+			right:    Tags{},
+			expected: Tags{},
+		},
+	}
+
+	for _, tc := range testCases {
+		left := tc.left.Clone()
+		left.Intersect(tc.right)
+		assert.Equal(t, tc.expected, left, "[left]"+tc.name)
+
+		right := tc.right.Clone()
+		right.Intersect(tc.left)
+		assert.Equal(t, tc.expected, right, "[right] "+tc.name)
+	}
+}
+
+func TestTagsJSON(t *testing.T) {
+	testCases := []struct {
+		name string
+		tags Tags
+	}{
+		{
+			name: "tags with values",
+			tags: Tags{
+				"t1": NewValueSet("v1", "v2"),
+				"t2": NewValueSet("v"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		// Marshal to bytes
+		bs, err := json.Marshal(tc.tags)
+		assert.NoError(t, err, tc.name+": marshal")
+
+		// Parse from bytes
+		var parsed Tags
+		err = json.Unmarshal(bs, &parsed)
+		assert.NoError(t, err, tc.name+": unmarshal")
+
+		// Check that we got what we started with
+		assert.Equal(t, tc.tags, parsed, tc.name+": round trip")
+	}
+}

--- a/tags/value_sets.go
+++ b/tags/value_sets.go
@@ -1,0 +1,88 @@
+package tags
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+type ValueSet map[Value]struct{}
+
+func NewValueSet(vs ...Value) ValueSet {
+	rv := make(ValueSet, len(vs))
+	for _, v := range vs {
+		rv[v] = struct{}{}
+	}
+	return rv
+}
+
+// Marshals ValueSet as a sorted list.
+func (vs ValueSet) MarshalJSON() ([]byte, error) {
+	return json.Marshal(vs.AsSlice())
+}
+
+// Parses ValueSet from a list, removing duplicates.
+func (vs *ValueSet) UnmarshalJSON(b []byte) error {
+	var slice []Value
+	if err := json.Unmarshal(b, &slice); err != nil {
+		return err
+	}
+
+	*vs = NewValueSet(slice...)
+
+	return nil
+}
+
+// Adds a value to this set.
+func (vs ValueSet) Add(v Value) {
+	vs[v] = struct{}{}
+}
+
+// Adds all values from other to v.
+func (vs ValueSet) AddAll(other ValueSet) {
+	for v, _ := range other {
+		vs.Add(v)
+	}
+}
+
+// Removes values in vs that are not in other.
+func (vs ValueSet) Intersect(other ValueSet) {
+	for v, _ := range vs {
+		if _, exists := other[v]; !exists {
+			delete(vs, v)
+		}
+	}
+}
+
+// Adds values to vs that are in other.
+func (vs ValueSet) Union(other ValueSet) {
+	for v, _ := range other {
+		vs.Add(v)
+	}
+}
+
+// Returns the smallest value in the set.  If the set is empty, returns
+// exists == false.
+func (vs ValueSet) GetFirst() (v Value, exists bool) {
+	if len(vs) == 0 {
+		return "", false
+	}
+	return vs.AsSlice()[0], true
+}
+
+// Returns a sorted slice of values.
+func (vs ValueSet) AsSlice() []Value {
+	slice := make([]Value, 0, len(vs))
+	for v, _ := range vs {
+		slice = append(slice, v)
+	}
+	sort.Strings(slice)
+	return slice
+}
+
+func (vs ValueSet) Clone() ValueSet {
+	rv := make(ValueSet, len(vs))
+	for v, _ := range vs {
+		rv.Add(v)
+	}
+	return rv
+}

--- a/tags/value_sets.go
+++ b/tags/value_sets.go
@@ -37,13 +37,6 @@ func (vs ValueSet) Add(v Value) {
 	vs[v] = struct{}{}
 }
 
-// Adds all values from other to v.
-func (vs ValueSet) AddAll(other ValueSet) {
-	for v, _ := range other {
-		vs.Add(v)
-	}
-}
-
 // Removes values in vs that are not in other.
 func (vs ValueSet) Intersect(other ValueSet) {
 	for v, _ := range vs {
@@ -53,7 +46,7 @@ func (vs ValueSet) Intersect(other ValueSet) {
 	}
 }
 
-// Adds values to vs that are in other.
+// Adds values from other to vs.
 func (vs ValueSet) Union(other ValueSet) {
 	for v, _ := range other {
 		vs.Add(v)

--- a/tags/value_sets_test.go
+++ b/tags/value_sets_test.go
@@ -16,15 +16,6 @@ func TestAdd(t *testing.T) {
 	assert.Equal(t, NewValueSet("v", "v2"), vs, "two values")
 }
 
-func TestAddAll(t *testing.T) {
-	vs := NewValueSet()
-	vs.AddAll(NewValueSet("v"))
-	assert.Equal(t, NewValueSet("v"), vs, "single value")
-
-	vs.AddAll(NewValueSet("v2"))
-	assert.Equal(t, NewValueSet("v", "v2"), vs, "two values")
-}
-
 func TestValueSetUnion(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/tags/value_sets_test.go
+++ b/tags/value_sets_test.go
@@ -1,0 +1,152 @@
+package tags
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	vs := NewValueSet()
+	vs.Add("v")
+	assert.Equal(t, NewValueSet("v"), vs, "single value")
+
+	vs.Add("v2")
+	assert.Equal(t, NewValueSet("v", "v2"), vs, "two values")
+}
+
+func TestAddAll(t *testing.T) {
+	vs := NewValueSet()
+	vs.AddAll(NewValueSet("v"))
+	assert.Equal(t, NewValueSet("v"), vs, "single value")
+
+	vs.AddAll(NewValueSet("v2"))
+	assert.Equal(t, NewValueSet("v", "v2"), vs, "two values")
+}
+
+func TestValueSetUnion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		left     ValueSet
+		right    ValueSet
+		expected ValueSet
+	}{
+		{
+			name:     "union with duplicates",
+			left:     NewValueSet("v1", "v2", "v3"),
+			right:    NewValueSet("v2", "v3", "v4"),
+			expected: NewValueSet("v1", "v2", "v3", "v4"),
+		},
+		{
+			name:     "empty sets remain empty",
+			left:     NewValueSet(),
+			right:    NewValueSet(),
+			expected: NewValueSet(),
+		},
+		{
+			name:     "empty set is idempotent",
+			left:     NewValueSet("v1", "v2"),
+			right:    NewValueSet(),
+			expected: NewValueSet("v1", "v2"),
+		},
+		{
+			name:     "union no duplicates",
+			left:     NewValueSet("v1"),
+			right:    NewValueSet("v1"),
+			expected: NewValueSet("v1"),
+		},
+	}
+
+	for _, tc := range testCases {
+		left := tc.left.Clone()
+		left.Union(tc.right)
+		assert.Equal(t, tc.expected, left, "[left]"+tc.name)
+
+		right := tc.right.Clone()
+		right.Union(tc.left)
+		assert.Equal(t, tc.expected, right, "[right] "+tc.name)
+	}
+}
+
+func TestValueSetIntersect(t *testing.T) {
+	testCases := []struct {
+		name     string
+		left     ValueSet
+		right    ValueSet
+		expected ValueSet
+	}{
+		{
+			name:     "intersect with duplicates",
+			left:     NewValueSet("v1", "v1", "v2"),
+			right:    NewValueSet("v1", "v1", "v1"),
+			expected: NewValueSet("v1"),
+		},
+		{
+			name:     "empty tags remain empty",
+			left:     NewValueSet(),
+			right:    NewValueSet(),
+			expected: NewValueSet(),
+		},
+		{
+			name:     "empty list is an annihilator",
+			left:     NewValueSet("v1", "v1", "v2"),
+			right:    NewValueSet(),
+			expected: NewValueSet(),
+		},
+	}
+
+	for _, tc := range testCases {
+		left := tc.left.Clone()
+		left.Intersect(tc.right)
+		assert.Equal(t, tc.expected, left, "[left]"+tc.name)
+
+		right := tc.right.Clone()
+		right.Intersect(tc.left)
+		assert.Equal(t, tc.expected, right, "[right] "+tc.name)
+	}
+}
+
+func TestGetFirst(t *testing.T) {
+	f, exists := NewValueSet("v2", "v1").GetFirst()
+	assert.True(t, exists, "get first exists")
+	assert.Equal(t, "v1", f, "get first")
+
+	_, exists = NewValueSet().GetFirst()
+	assert.False(t, exists, "get first doesn't exist")
+}
+
+func TestAsSlice(t *testing.T) {
+	assert.Equal(t, []Value{}, NewValueSet().AsSlice(), "as empty slice")
+	assert.Equal(t, []Value{"v1", "v2"}, NewValueSet("v2", "v1").AsSlice(), "as slice")
+}
+
+func TestValueSetJSON(t *testing.T) {
+	testCases := []struct {
+		name string
+		vs   ValueSet
+	}{
+		{
+			name: "value set with values",
+			vs:   NewValueSet("v1", "v2"),
+		},
+		{
+			name: "empty value set",
+			vs:   NewValueSet(),
+		},
+	}
+
+	for _, tc := range testCases {
+		// Marshal to bytes
+		bs, err := json.Marshal(tc.vs)
+		assert.NoError(t, err, tc.name+": marshal")
+
+		// Parse from bytes
+		var parsed ValueSet
+		err = json.Unmarshal(bs, &parsed)
+		assert.NoError(t, err, tc.name+": unmarshal")
+
+		// Check that we got what we started with
+		assert.Equal(t, tc.vs, parsed, tc.name+": round trip")
+	}
+}


### PR DESCRIPTION
After thinking about it, I'm not convinced it was safe to change the tag fields
in 10b6ba80886d956ba3d08a31a8b63bd99555b92c.

This PR reverts those changes, introduces new tags abstractions that
distinguishes between singleton tag maps and multiset tag maps, and adds new
response fields where we expect to expose multiset tag maps.