### PR TITLE
Extend map heuristics

### DIFF
--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -2,12 +2,11 @@ package spec_util
 
 import (
 	"fmt"
-	"reflect"
-	"sort"
-	"strconv"
-
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
+	"reflect"
+	"regexp"
+	"sort"
 
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
@@ -504,16 +503,10 @@ func StructShouldBeMap(struc *pb.Struct) bool {
 	return false
 }
 
+var startsWithNumberRegexp = regexp.MustCompile(`^\d`)
+
 func startsWithNumber(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
-
-	if _, err := strconv.Atoi(s[0:1]); err != nil {
-		return false
-	}
-
-	return true
+	return startsWithNumberRegexp.MatchString(s)
 }
 
 // Melds two maps together. The given pb.Structs are assumed to represent maps.

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
@@ -450,7 +451,7 @@ func (m *melder) meldStruct(dst, src *pb.Struct) error {
 	}
 
 	// Apply a heuristic for deciding when to convert structs to maps.
-	if structShouldBeMap(dst) {
+	if StructShouldBeMap(dst) {
 		m.structToMap(dst)
 	}
 
@@ -465,10 +466,11 @@ func isMap(struc *pb.Struct) bool {
 // Tuning parameters for deciding when a struct should be turned into a map.
 const maxOptionalFieldsPerStruct = 50
 const maxFieldsPerStruct = 100
+const minNumberedFields = 10
 
 // Heuristically determines whether the given pb.Struct (assumed to not
 // represent a map) should be a map.
-func structShouldBeMap(struc *pb.Struct) bool {
+func StructShouldBeMap(struc *pb.Struct) bool {
 	// A struct should be a map if its total number of fields exceeds
 	// maxFieldsPerStruct.
 	if len(struc.Fields) > maxFieldsPerStruct {
@@ -478,16 +480,40 @@ func structShouldBeMap(struc *pb.Struct) bool {
 	// A struct should be a map if its number of optional fields exceeds
 	// maxOptionalFieldsPerStruct.
 	numOptionalFields := 0
-	for _, field := range struc.Fields {
+	allFieldsStartWithNumbers := true
+	for fieldName, field := range struc.Fields {
 		if field.GetOptional() != nil {
 			numOptionalFields++
 			if numOptionalFields > maxOptionalFieldsPerStruct {
 				return true
 			}
 		}
+		if !startsWithNumber(fieldName) {
+			allFieldsStartWithNumbers = false
+		}
+	}
+
+	// A struct should be a map if all its fields start with numbers and there
+	// are a sufficient number of fields.  Because many programming languages
+	// disallow struct names starting with numbers, the number of fields is
+	// lower.
+	if allFieldsStartWithNumbers && len(struc.Fields) >= minNumberedFields {
+		return true
 	}
 
 	return false
+}
+
+func startsWithNumber(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+
+	if _, err := strconv.Atoi(s[0:1]); err != nil {
+		return false
+	}
+
+	return true
 }
 
 // Melds two maps together. The given pb.Structs are assumed to represent maps.

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -236,6 +236,14 @@ var tests = []testData{
 		},
 		"testdata/meld/meld_map_1_map_2_expected.pb.txt",
 	},
+	{
+		"structs with number fields",
+		[]string{
+			"testdata/meld/meld_map_4.pb.txt",
+			"testdata/meld/meld_map_5.pb.txt",
+		},
+		"testdata/meld/meld_map_4_map_5_expected.pb.txt",
+	},
 }
 
 func TestMeldWithFormats(t *testing.T) {
@@ -533,9 +541,9 @@ func TestMeldData(t *testing.T) {
 				PotentialConflict: true,
 			}),
 			right: wrapPrim(&pb.Primitive{
-				Value: &pb.Primitive_Int64Value{Int64Value: &pb.Int64{}},
+				Value:      &pb.Primitive_Int64Value{Int64Value: &pb.Int64{}},
 				FormatKind: "datetime",
-				Formats: map[string]bool{"timestamp": true},
+				Formats:    map[string]bool{"timestamp": true},
 			}),
 			expected: wrapOneOf(&pb.OneOf{
 				Options: map[string]*pb.Data{

--- a/spec_util/testdata/meld/meld_map_4.pb.txt
+++ b/spec_util/testdata/meld/meld_map_4.pb.txt
@@ -1,0 +1,360 @@
+# api_spec.Witness proto
+
+method {
+  id {
+    api_type: HTTP_REST
+  }
+
+  args {
+    key: "_uRKmYFjfd4="
+    value {
+      struct {
+        fields {
+          key: "2022-01-01"
+            value {
+              primitive {
+                string_value {
+                }
+              }
+            }
+          }
+        fields {
+          key: "2022-01-02"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-03"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-04"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-05"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-06"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-07"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-08"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-09"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-10"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+      }
+      meta {
+        http {
+          body {
+            content_type: JSON
+          }
+        }
+      }
+    }
+  }
+
+  responses {
+    key: "FiNRlcJh7SI="
+    value {
+      struct {
+        fields {
+          key: "addr1@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr2@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr3@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr4@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr5@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr6@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr7@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr8@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr9@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr10@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr11@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr12@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr13@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr14@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr15@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr16@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr17@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr18@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr19@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr20@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr21@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr22@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr23@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr24@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr25@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+      }
+      meta {
+        http {
+          body {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+  meta {
+    http {
+      method: "GET"
+      path_template: "/t1"
+      host: "kafka"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_map_4_map_5_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_map_4_map_5_expected.pb.txt
@@ -1,0 +1,71 @@
+# api_spec.Witness proto
+
+method <
+  id: <
+    api_type: HTTP_REST
+  >
+  args: <
+    key: "_uRKmYFjfd4="
+    value: <
+      struct: <
+        map_type: <
+          key: <
+            primitive: <
+              string_value: <
+              >
+            >
+          >
+          value: <
+            primitive: <
+              string_value: <
+              >
+            >
+          >
+        >
+      >
+      meta: <
+        http: <
+          body: <
+            content_type: JSON
+          >
+        >
+      >
+    >
+  >
+  responses: <
+    key: "r4OCR99LKF4="
+    value: <
+      struct: <
+        map_type: <
+          key: <
+            primitive: <
+              string_value: <
+              >
+            >
+          >
+          value: <
+            primitive: <
+              string_value: <
+              >
+            >
+          >
+        >
+      >
+      meta: <
+        http: <
+          body: <
+            content_type: JSON
+          >
+          response_code: 200
+        >
+      >
+    >
+  >
+  meta: <
+    http: <
+      method: "GET"
+      path_template: "/t1"
+      host: "kafka"
+    >
+  >
+>

--- a/spec_util/testdata/meld/meld_map_5.pb.txt
+++ b/spec_util/testdata/meld/meld_map_5.pb.txt
@@ -1,0 +1,324 @@
+# api_spec.Witness proto
+
+method {
+  id {
+    api_type: HTTP_REST
+  }
+
+  args {
+    key: "_uRKmYFjfd4="
+    value {
+      struct {
+        fields {
+          key: "2022-01-01"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-02"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-03"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-04"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "2022-01-05"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+      }
+      meta {
+        http {
+          body {
+            content_type: JSON
+          }
+        }
+      }
+    }
+  }
+
+  responses {
+    key: "xwqc_a6WGWE="
+    value {
+      struct {
+        fields {
+          key: "addr26@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr27@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr28@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr29@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr30@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr31@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr32@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr33@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr34@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr35@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr36@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr37@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr38@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr39@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr40@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr41@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr42@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr43@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr44@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr45@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr46@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr47@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr48@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr49@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr50@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "addr51@example.com"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+      }
+      meta {
+        http {
+          body {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+  meta {
+    http {
+      method: "GET"
+      path_template: "/t1"
+      host: "kafka"
+    }
+  }
+}


### PR DESCRIPTION
We use heuristics to decide when a JSON object in an API is a map
(dictionary) with variable data keys rather than a fixed part of the
API.

This PR extends the heuristics to account for objects with fields that
begin with numbers -- this covers common data formats like numbers,
datetimes, etc.  If every field in a struct beings with a number and
there are sufficient fields, we consider it to be a map.