### PR TITLE
Infer maps more aggressively

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1
+	golang.org/x/exp v0.0.0-20220428152302-39d4317da171
 	google.golang.org/protobuf v1.27.1
 )
 
@@ -23,7 +24,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
-	golang.org/x/exp v0.0.0-20220428152302-39d4317da171 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/spec_util/infer_maps.go
+++ b/spec_util/infer_maps.go
@@ -8,6 +8,18 @@ import (
 	"github.com/akitasoftware/akita-libs/visitors/http_rest"
 )
 
+// The maximum number of optional fields a struct can have before it's inferred
+// to be a map.
+const maxOptionalFieldsPerStruct = 50
+
+// The maximum number of fields a struct can have before it's inferred to be a
+// map.
+const maxFieldsPerStruct = 100
+
+// A struct is inferred to be a map if it has more than this number of fields
+// whose name starts with a number.
+const maxNumberedFieldsPerStruct = 10
+
 // Heuristically determines whether the given pb.Struct (assumed to not
 // represent a map) should be a map.
 func StructShouldBeMap(struc *pb.Struct) bool {
@@ -20,7 +32,7 @@ func StructShouldBeMap(struc *pb.Struct) bool {
 	// A struct should be a map if its number of optional fields exceeds
 	// maxOptionalFieldsPerStruct.
 	numOptionalFields := 0
-	allFieldsStartWithNumbers := true
+	numNumberedFields := 0
 	for fieldName, field := range struc.Fields {
 		if field.GetOptional() != nil {
 			numOptionalFields++
@@ -28,17 +40,12 @@ func StructShouldBeMap(struc *pb.Struct) bool {
 				return true
 			}
 		}
-		if !startsWithNumber(fieldName) {
-			allFieldsStartWithNumbers = false
+		if startsWithNumber(fieldName) {
+			numNumberedFields++
+			if numNumberedFields > maxNumberedFieldsPerStruct {
+				return true
+			}
 		}
-	}
-
-	// A struct should be a map if all its fields start with numbers and there
-	// are a sufficient number of fields.  Because many programming languages
-	// disallow struct names starting with numbers, the number of fields is
-	// lower.
-	if allFieldsStartWithNumbers && len(struc.Fields) >= minNumberedFields {
-		return true
 	}
 
 	return false

--- a/spec_util/infer_maps.go
+++ b/spec_util/infer_maps.go
@@ -18,7 +18,7 @@ const maxFieldsPerStruct = 100
 
 // A struct is inferred to be a map if it has more than this number of fields
 // whose name starts with a number.
-const maxNumberedFieldsPerStruct = 10
+const maxNumberedFieldsPerStruct = 9
 
 // Heuristically determines whether the given pb.Struct (assumed to not
 // represent a map) should be a map.

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -462,11 +462,6 @@ func isMap(struc *pb.Struct) bool {
 	return struc.MapType != nil
 }
 
-// Tuning parameters for deciding when a struct should be turned into a map.
-const maxOptionalFieldsPerStruct = 50
-const maxFieldsPerStruct = 100
-const minNumberedFields = 10
-
 // Melds two maps together. The given pb.Structs are assumed to represent maps.
 func (m *melder) meldMap(dst, src *pb.Struct) error {
 	// Try to make the key and value in dst non-nil.


### PR DESCRIPTION
Infer a struct to be a map if it has more than a threshold number of fields whose name starts with a number.