### PR TITLE
Added a couple of qualified IDs

### DIFF
--- a/akid/qualified_ids.go
+++ b/akid/qualified_ids.go
@@ -1,0 +1,13 @@
+package akid
+
+// A service ID paired with its organization ID.
+type QualifiedServiceID struct {
+	organizationID OrganizationID
+	serviceID      ServiceID
+}
+
+// A learn session ID paired with its service ID and organization ID.
+type QualifiedLearnSessionID struct {
+	QualifiedServiceID
+	learnSessionID LearnSessionID
+}


### PR DESCRIPTION
Added `QualifiedServiceID` for carrying a service ID with its organization ID. Also added `QualifiedLearnSessionID` for carrying similar context with a learn session ID.