### PR TITLE
Report which spans have incomplete data in timeline response.

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -451,6 +451,9 @@ type TimelineResponse struct {
 
 	// If incomplete due to limit, the first unreported start time
 	NextStartTime *time.Time `json:"next_start_time,omitempty"`
+
+	// Time spans that have incomplete data.
+	IncompleteSpans []time_span.HalfOpenInterval `json:"incomplete_spans,omitempty"`
 }
 
 // An HTTP request and response between two nodes in a graph.


### PR DESCRIPTION
This API change will allow the timeline query API to indicate which portions of the response have incomplete data.

@paul-russo, I don't expect that you need to use this immediately but if you'd prefer the data be communicated in some other way, let me know.