### PR TITLE
Add TLS hello count to packet capture counts.

### DIFF
--- a/client_telemetry/pcap_stats.go
+++ b/client_telemetry/pcap_stats.go
@@ -12,6 +12,7 @@ type PacketCounts struct {
 	TCPPackets    int `json:"tcp_packets"`
 	HTTPRequests  int `json:"http_requests"`
 	HTTPResponses int `json:"http_responses"`
+	TLSHello      int `json:"tls_hello"`
 	Unparsed      int `json:"unparsed"`
 }
 
@@ -19,6 +20,7 @@ func (c *PacketCounts) Add(d PacketCounts) {
 	c.TCPPackets += d.TCPPackets
 	c.HTTPRequests += d.HTTPRequests
 	c.HTTPResponses += d.HTTPResponses
+	c.TLSHello += d.TLSHello
 	c.Unparsed += d.Unparsed
 }
 
@@ -33,7 +35,7 @@ func (c *PacketCounts) Copy() *PacketCounts {
 // Reflects the version of the JSON encoding.  Increase the minor version
 // number for backwards-compatible changes and the major number for non-
 // backwards compatible changes.
-const Version = "v0"
+const Version = "v0.1"
 
 type PacketCountSummary struct {
 	Version        string                   `json:"version"`


### PR DESCRIPTION
(Does not distinguish client and server handshakes.)