### PR TITLE
Manage cookies in akinet requests/responses

### DIFF
--- a/akinet/std.go
+++ b/akinet/std.go
@@ -2,12 +2,13 @@ package akinet
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/akitasoftware/akita-libs/buffer_pool"
 	"github.com/akitasoftware/go-utils/sets"
 	"github.com/akitasoftware/go-utils/slices"
 	"github.com/google/uuid"
-	"io/ioutil"
-	"net/http"
 )
 
 func FromStdRequest(streamID uuid.UUID, seq int, src *http.Request, body buffer_pool.Buffer) HTTPRequest {
@@ -40,6 +41,7 @@ func (r HTTPRequest) ToStdRequest() *http.Request {
 		Body:          ioutil.NopCloser(r.Body.CreateReader()),
 	}
 
+	// Add any cookies in r.Cookies not already in r.Header.
 	existingCookies := sets.NewSet[string](slices.Map(result.Cookies(), func(c *http.Cookie) string {
 		return c.String()
 	})...)
@@ -80,6 +82,7 @@ func (r HTTPResponse) ToStdResponse() *http.Response {
 		Body:          ioutil.NopCloser(r.Body.CreateReader()),
 	}
 
+	// Add any cookies in r.Cookies not already in r.Header.
 	existingCookies := sets.NewSet[string](slices.Map(response.Cookies(), func(c *http.Cookie) string {
 		return c.String()
 	})...)

--- a/akinet/std.go
+++ b/akinet/std.go
@@ -18,6 +18,7 @@ func FromStdRequest(streamID uuid.UUID, seq int, src *http.Request, body buffer_
 		ProtoMinor: src.ProtoMinor,
 		URL:        src.URL,
 		Host:       src.Host,
+		Cookies:    src.Cookies(),
 		Header:     src.Header,
 		Body:       body.Bytes(),
 
@@ -51,6 +52,7 @@ func FromStdResponse(streamID uuid.UUID, seq int, src *http.Response, body buffe
 		StatusCode: src.StatusCode,
 		ProtoMajor: src.ProtoMajor,
 		ProtoMinor: src.ProtoMinor,
+		Cookies:    src.Cookies(),
 		Header:     src.Header,
 		Body:       body.Bytes(),
 
@@ -59,7 +61,7 @@ func FromStdResponse(streamID uuid.UUID, seq int, src *http.Response, body buffe
 }
 
 func (r HTTPResponse) ToStdResponse() *http.Response {
-	return &http.Response{
+	response := &http.Response{
 		Status:        http.StatusText(r.StatusCode),
 		StatusCode:    r.StatusCode,
 		Proto:         fmt.Sprintf("HTTP/%d.%d", r.ProtoMajor, r.ProtoMinor),
@@ -69,4 +71,12 @@ func (r HTTPResponse) ToStdResponse() *http.Response {
 		ContentLength: int64(r.Body.Len()),
 		Body:          ioutil.NopCloser(r.Body.CreateReader()),
 	}
+
+	for _, c := range r.Cookies {
+		if v := c.String(); v != "" {
+			response.Header.Add("Set-Cookie", v)
+		}
+	}
+
+	return response
 }

--- a/akinet/std_test.go
+++ b/akinet/std_test.go
@@ -1,0 +1,86 @@
+package akinet
+
+import (
+	"github.com/akitasoftware/akita-libs/buffer_pool"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestRequestConversion(t *testing.T) {
+	testBidiID := TCPBidiID(uuid.MustParse("3744e3d7-2c08-4cd2-9ee9-2306dfba6727"))
+	cases := []struct {
+		name  string
+		input HTTPRequest
+	}{
+		{
+			name: "simple request with cookies",
+			input: HTTPRequest{
+				StreamID:   uuid.UUID(testBidiID),
+				Seq:        1203,
+				Method:     "GET",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				URL:        &url.URL{Path: "/"},
+				Host:       "example.com",
+				Cookies: []*http.Cookie{
+					{Name: "c1", Value: "1"},
+					{Name: "c2", Value: "2"},
+				},
+				Header: map[string][]string{
+					"Cookie": {"c1=1;c2=2"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		pool, err := buffer_pool.MakeBufferPool(1024, 1024)
+		assert.NoError(t, err)
+		buffer := pool.NewBuffer()
+		_, err = buffer.Write([]byte(tc.input.Body.String()))
+		assert.NoError(t, err)
+		tc.input.buffer = buffer
+
+		assert.Equal(t, tc.input, FromStdRequest(tc.input.StreamID, tc.input.Seq, tc.input.ToStdRequest(), buffer), tc.name)
+	}
+}
+
+func TestResponseConversion(t *testing.T) {
+	testBidiID := TCPBidiID(uuid.MustParse("3744e3d7-2c08-4cd2-9ee9-2306dfba6727"))
+	cases := []struct {
+		name  string
+		input HTTPResponse
+	}{
+		{
+			name: "simple response with set cookie",
+			input: HTTPResponse{
+				StreamID:   uuid.UUID(testBidiID),
+				Seq:        522,
+				StatusCode: 204,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Cookies: []*http.Cookie{
+					{Name: "c1", Value: "1", Raw: "c1=1"},
+				},
+				Header: map[string][]string{
+					"Set-Cookie":  {"c1=1"},
+					"X-Akita-Dog": {"prince"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		pool, err := buffer_pool.MakeBufferPool(1024, 1024)
+		assert.NoError(t, err)
+		buffer := pool.NewBuffer()
+		_, err = buffer.Write([]byte(tc.input.Body.String()))
+		assert.NoError(t, err)
+		tc.input.buffer = buffer
+
+		assert.Equal(t, tc.input, FromStdResponse(tc.input.StreamID, tc.input.Seq, tc.input.ToStdResponse(), buffer), tc.name)
+	}
+}


### PR DESCRIPTION
The akinet library has request and response structs that mirror http.Request
and http.Response.  As a convenience, the akinet structs have a Cookies field
that copies cookies from Headers.

This PR ensures that the Cookies field is populated when converting between
akinet and http objects.