### PR TITLE
Add Getters to Analytics Event struct

### DIFF
--- a/analytics/event.go
+++ b/analytics/event.go
@@ -32,3 +32,11 @@ func (e *Event) SetTime(t time.Time) *Event {
 	e.timestamp = t
 	return e
 }
+
+func (e *Event) DistinctID() string {
+	return e.distinctID
+}
+
+func (e *Event) Name() string {
+	return e.name
+}


### PR DESCRIPTION
This will add getters for an analytics event's distinct ID and name. These getters should make it easier to perform granular error handling given an `Event` fails to be enqueued.