### PR TITLE
Add tags for scheduled model types

### DIFF
--- a/tags/reserved_tags.go
+++ b/tags/reserved_tags.go
@@ -16,6 +16,9 @@ const (
 
 	// The original filesystem path of an uploaded trace.
 	XAkitaTraceLocalPath Key = "x-akita-trace-local-path"
+	
+	// The type of scheduled model, if XAkitaCreatedBy == CreatedBySchedule.
+	XAkitaScheduledModelType Key = "x-akita-scheduled-model-type"
 
 	// The version of the service(s) under observation, as defined by the
 	// user.

--- a/tags/scheduled_model_type.go
+++ b/tags/scheduled_model_type.go
@@ -1,0 +1,20 @@
+package tags
+
+type ScheduledModelType = string
+
+// Valid values for the XAkitaScheduledModelType tag.
+const (
+	// Designates a spec that was created as a "large model".  We show the
+	// latest large model on the API Model page in the Akita app.
+	ScheduledLargeModel ScheduledModelType = "large-model"
+
+	// Designates a spec that was created as a large diffing model.  The
+	// most recent large diffing model is used when computing model
+	// differences.
+	ScheduledLargeDiffingModel ScheduledModelType = "large-diffing-model"
+	
+	// Designates a spec that was created as a small diffing model.  The
+	// most recent small diffing model is used when computing model
+	// differences.
+	ScheduledSmallDiffingModel ScheduledModelType = "small-diffing-model"
+)


### PR DESCRIPTION
Adds a new tag for scheduled model types, e.g. large models and diffing models.