### PR TITLE
Recognize HTTP/2 traffic

### DIFF
--- a/akinet/http2/parser_factory.go
+++ b/akinet/http2/parser_factory.go
@@ -86,8 +86,9 @@ func (s *http2Sink) Parse(input memview.MemView, isEnd bool) (result akinet.Pars
 		return akinet.HTTP2ConnectionPreface{}, memview.Empty(), input.Len(), nil
 	}
 
-	// The interface documentation says we must return a non-nil result or error at isEnd.
-	// I am violating that by returning nil, but the code in stream.go can handle that, I believe.
+	// The interface documentation says we must return a non-nil result or an
+	// error when isEnd is true. I am violating that by returning nil, but the
+	// code in stream.go can handle that, I believe.
 	s.totalBytesConsumed += input.Len()
 	return nil, memview.Empty(), s.totalBytesConsumed, nil
 }

--- a/akinet/http2/parser_factory.go
+++ b/akinet/http2/parser_factory.go
@@ -1,0 +1,93 @@
+package http2
+
+import (
+	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/akitasoftware/akita-libs/memview"
+	"github.com/google/gopacket/reassembly"
+)
+
+// This parser only recognizes HTTP/2 connection prefaces.
+//
+// The "client connection preface" is used with known HTTP/2
+// servers, or after the negotiation with the 'Upgrade: h2c`
+// header is completed.
+func NewHTTP2PrefaceParserFactory() akinet.TCPParserFactory {
+	return &http2PrefaceParserFactory{}
+}
+
+type http2PrefaceParserFactory struct {
+}
+
+func (http2PrefaceParserFactory) Name() string {
+	return "HTTP/2 Connection Preface Parser Factory"
+}
+
+// 24 octets: "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+var connectionPreface []byte = []byte{
+	0x50, 0x52, 0x49, 0x20, 0x2a, 0x20, 0x48, 0x54,
+	0x54, 0x50, 0x2f, 0x32, 0x2e, 0x30, 0x0d, 0x0a,
+	0x0d, 0x0a, 0x53, 0x4d, 0x0d, 0x0a, 0x0d, 0x0a,
+}
+
+var connectionPrefaceFirstByte []byte = connectionPreface[:1]
+
+func (http2PrefaceParserFactory) Accepts(input memview.MemView, isEnd bool) (decision akinet.AcceptDecision, discardFront int64) {
+	if input.Len() < int64(len(connectionPreface)) {
+		if isEnd {
+			return akinet.Reject, input.Len()
+		}
+		return akinet.NeedMoreData, 0
+	}
+
+	if start := input.Index(0, connectionPreface); start >= 0 {
+		return akinet.Accept, start
+	}
+
+	// If there is a partial match at the end of the stream, then we should
+	// leave those bytes alone. Unfortunately, input.Index proved to be
+	// too hard to adapt to return partial match locations (because bytes.Index
+	// does not either) so here is a hack to avoid just returning (NeedMoreData, 23)
+	// all the time. We'll just look for the first byte.
+	if isEnd {
+		return akinet.Reject, input.Len()
+	}
+
+	nMinus1Suffix := input.Len() - int64(len(connectionPreface)) + 1
+	possible := input.Index(nMinus1Suffix, connectionPrefaceFirstByte)
+	if possible >= 0 {
+		return akinet.NeedMoreData, possible
+	}
+	return akinet.Reject, input.Len()
+}
+
+// Once we've found a HTTP/2 connection preface, the rest of the connection
+// can be assumed to be HTTP/2 (or, I suppose, an error.)  There is no way
+// to downgrade, so we can throw away all subsequent data.
+type http2Sink struct {
+	firstInput         bool
+	totalBytesConsumed int64
+}
+
+func (http2PrefaceParserFactory) CreateParser(id akinet.TCPBidiID, seq, ack reassembly.Sequence) akinet.TCPParser {
+	return &http2Sink{
+		firstInput: true,
+	}
+}
+
+func (*http2Sink) Name() string {
+	return "HTTP/2 sink"
+}
+
+func (s *http2Sink) Parse(input memview.MemView, isEnd bool) (result akinet.ParsedNetworkContent, unused memview.MemView, totalBytesConsumed int64, err error) {
+	// Return one event at the start of the stream, so we can count it.
+	if s.firstInput {
+		s.firstInput = false
+		s.totalBytesConsumed = 0
+		return akinet.HTTP2ConnectionPreface{}, memview.Empty(), input.Len(), nil
+	}
+
+	// The interface documentation says we must return a non-nil result or error at isEnd.
+	// I am violating that by returning nil, but the code in stream.go can handle that, I believe.
+	s.totalBytesConsumed += input.Len()
+	return nil, memview.Empty(), s.totalBytesConsumed, nil
+}

--- a/akinet/http2/parser_factory_test.go
+++ b/akinet/http2/parser_factory_test.go
@@ -1,0 +1,76 @@
+package http2
+
+import (
+	"testing"
+
+	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/akitasoftware/akita-libs/memview"
+)
+
+// TODO: the nice "segment" utility from http/1 tests is not exported,
+// so we have more manual splitting in place here.
+
+func TestHTTP2Preface(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		VerbatimInput    [][]byte
+		expectedDecision akinet.AcceptDecision
+		expectedDF       int64
+	}{
+		{
+			"whole at start",
+			[][]byte{connectionPreface},
+			akinet.Accept,
+			0,
+		},
+		{
+			"split in two",
+			[][]byte{connectionPreface[0:8], connectionPreface[8:]},
+			akinet.Accept,
+			0,
+		},
+		{
+			"junk before preface",
+			[][]byte{[]byte("abcdef"), connectionPreface[0:8], connectionPreface[8:]},
+			akinet.Accept,
+			6,
+		},
+		{
+			"junk before preface 2",
+			[][]byte{[]byte("abcdefP"), connectionPreface[1:8], connectionPreface[8:]},
+			akinet.Accept,
+			6,
+		},
+		{
+			"http/1.1 code",
+			[][]byte{[]byte("GET /bulk/this/out/some/so/its/long HTTP/1.1\r\n")},
+			akinet.Reject,
+			46,
+		},
+	}
+
+	fact := NewHTTP2PrefaceParserFactory()
+
+	for _, tc := range testCases {
+		var decision akinet.AcceptDecision
+		var input memview.MemView
+		var totalLen int64
+		for i, b := range tc.VerbatimInput {
+			totalLen += int64(len(b))
+			input.Append(memview.New(b))
+
+			atEnd := (i == len(tc.VerbatimInput)-1)
+			d, df := fact.Accepts(input, atEnd)
+			decision = d
+			input = input.SubView(df, input.Len())
+		}
+
+		discardFront := totalLen - input.Len()
+		if tc.expectedDecision != decision {
+			t.Errorf("[%s] expected decision %s, got %s", tc.Name, tc.expectedDecision, decision)
+		}
+		if tc.expectedDF != discardFront {
+			t.Errorf("[%s] expected discard front %d, got %d", tc.Name, tc.expectedDF, discardFront)
+		}
+	}
+}

--- a/akinet/net_traffic.go
+++ b/akinet/net_traffic.go
@@ -374,6 +374,23 @@ func (tls *TLSHandshakeMetadata) ApplicationLatencyMeasurable() bool {
 	return *tls.SelectedProtocol == "http/1.1"
 }
 
+// Represents an observed HTTP/2 connection preface; no data from it
+// is stored.
+type HTTP2ConnectionPreface struct {
+}
+
+func (HTTP2ConnectionPreface) implParsedNetworkContent() {}
+func (HTTP2ConnectionPreface) ReleaseBuffers()           {}
+
+// Represents an observed QUIC handshake (initial packet).
+// Currently empty because we're only interested in the presence
+// of QUIC traffic, not its payload.
+type QUICHandshakeMetadata struct {
+}
+
+func (QUICHandshakeMetadata) implParsedNetworkContent() {}
+func (QUICHandshakeMetadata) ReleaseBuffers()           {}
+
 // For testing only.
 type AkitaPrince string
 

--- a/client_telemetry/pcap_stats.go
+++ b/client_telemetry/pcap_stats.go
@@ -13,8 +13,8 @@ type PacketCounts struct {
 	HTTPRequests  int `json:"http_requests"`
 	HTTPResponses int `json:"http_responses"`
 	TLSHello      int `json:"tls_hello"`
-	HTTP2Preface  int `json:"http2_preface"`
-	QUICHandshake int `json:"quic_handshake"`
+	HTTP2Prefaces  int `json:"http2_prefaces"`
+	QUICHandshakes int `json:"quic_handshakes"`
 	Unparsed      int `json:"unparsed"`
 }
 

--- a/client_telemetry/pcap_stats.go
+++ b/client_telemetry/pcap_stats.go
@@ -9,13 +9,13 @@ type PacketCounts struct {
 	DstPort   int    `json:"dst_port"`
 
 	// Number of events
-	TCPPackets    int `json:"tcp_packets"`
-	HTTPRequests  int `json:"http_requests"`
-	HTTPResponses int `json:"http_responses"`
-	TLSHello      int `json:"tls_hello"`
+	TCPPackets     int `json:"tcp_packets"`
+	HTTPRequests   int `json:"http_requests"`
+	HTTPResponses  int `json:"http_responses"`
+	TLSHello       int `json:"tls_hello"`
 	HTTP2Prefaces  int `json:"http2_prefaces"`
 	QUICHandshakes int `json:"quic_handshakes"`
-	Unparsed      int `json:"unparsed"`
+	Unparsed       int `json:"unparsed"`
 }
 
 func (c *PacketCounts) Add(d PacketCounts) {
@@ -23,8 +23,8 @@ func (c *PacketCounts) Add(d PacketCounts) {
 	c.HTTPRequests += d.HTTPRequests
 	c.HTTPResponses += d.HTTPResponses
 	c.TLSHello += d.TLSHello
-	c.HTTP2Preface += d.HTTP2Preface
-	c.QUICHandshake += d.QUICHandshake
+	c.HTTP2Prefaces += d.HTTP2Prefaces
+	c.QUICHandshakes += d.QUICHandshakes
 	c.Unparsed += d.Unparsed
 }
 

--- a/client_telemetry/pcap_stats.go
+++ b/client_telemetry/pcap_stats.go
@@ -13,6 +13,8 @@ type PacketCounts struct {
 	HTTPRequests  int `json:"http_requests"`
 	HTTPResponses int `json:"http_responses"`
 	TLSHello      int `json:"tls_hello"`
+	HTTP2Preface  int `json:"http2_preface"`
+	QUICHandshake int `json:"quic_handshake"`
 	Unparsed      int `json:"unparsed"`
 }
 
@@ -21,6 +23,8 @@ func (c *PacketCounts) Add(d PacketCounts) {
 	c.HTTPRequests += d.HTTPRequests
 	c.HTTPResponses += d.HTTPResponses
 	c.TLSHello += d.TLSHello
+	c.HTTP2Preface += d.HTTP2Preface
+	c.QUICHandshake += d.QUICHandshake
 	c.Unparsed += d.Unparsed
 }
 
@@ -35,7 +39,7 @@ func (c *PacketCounts) Copy() *PacketCounts {
 // Reflects the version of the JSON encoding.  Increase the minor version
 // number for backwards-compatible changes and the major number for non-
 // backwards compatible changes.
-const Version = "v0.1"
+const Version = "v0.2"
 
 type PacketCountSummary struct {
 	Version        string                   `json:"version"`

--- a/memview/memview.go
+++ b/memview/memview.go
@@ -36,6 +36,14 @@ func New(data []byte) MemView {
 	}
 }
 
+// Make an empty memview
+func Empty() MemView {
+	return MemView{
+		buf:    [][]byte{},
+		length: 0,
+	}
+}
+
 func (dst *MemView) Append(src MemView) {
 	dst.buf = append(dst.buf, src.buf...)
 	dst.length += src.length


### PR DESCRIPTION
Added a (failing) unit test for HTTP/1 parsing.
New ParsedNetworkTraffic types for QUIC and HTTP/2 handshakes.
Parser factory that recognizes HTTP/2 connection preface.  (This comes at the start of the binary format, after upgrade from HTTP/1.1 is successful or the client is connecting to a known HTTP/2-capable server.)
Parser that simply drops everything associated with a HTTP/2 connection.
Unit tests for HTTP/2.
Counters for HTTP/2 and QUIC.