### PR TITLE
Make Integrations for Analytic Events Configurable

### DIFF
--- a/analytics/client.go
+++ b/analytics/client.go
@@ -72,10 +72,11 @@ func (c clientImpl) TrackEvent(event *Event) error {
 
 	segmentErr := c.segmentClient.Enqueue(
 		segment.Track{
-			UserId:     event.distinctID,
-			Event:      event.name,
-			Properties: event.properties,
-			Timestamp:  event.timestamp,
+			UserId:       event.distinctID,
+			Event:        event.name,
+			Properties:   event.properties,
+			Timestamp:    event.timestamp,
+			Integrations: event.integrations,
 		},
 	)
 
@@ -167,7 +168,7 @@ func (d analyticsLogger) Errorf(format string, args ...interface{}) {
 }
 
 // A custom segment logger that does nothing.
-//This is used when logging is disabled as the segment client requires a logger (the client uses its own default logger even when none is specified).
+// This is used when logging is disabled as the segment client requires a logger (the client uses its own default logger even when none is specified).
 type disabledLogger struct{}
 
 func (d disabledLogger) Logf(format string, args ...any) {

--- a/analytics/config.go
+++ b/analytics/config.go
@@ -31,7 +31,7 @@ type Config struct {
 
 	// Sets the default destination types that events will be sent to.
 	// If not set, events will be sent to all destinations.
-	DefaultIntegrations map[string]any `yaml:"default_integrations"`
+	DefaultIntegrations map[string]bool `yaml:"default_integrations"`
 }
 
 // Data pertaining to the application such as name, version, and build

--- a/analytics/config.go
+++ b/analytics/config.go
@@ -28,6 +28,10 @@ type Config struct {
 
 	// Disable batching (used for CLI) by setting this parameter to 1
 	BatchSize int `yaml:"batch_size"`
+
+	// Sets the default destination types that events will be sent to.
+	// If not set, events will be sent to all destinations.
+	DefaultIntegrations map[string]any `yaml:"default_integrations"`
 }
 
 // Data pertaining to the application such as name, version, and build

--- a/analytics/event.go
+++ b/analytics/event.go
@@ -1,6 +1,10 @@
 package analytics
 
-import "time"
+import (
+	"github.com/akitasoftware/go-utils/optionals"
+	segment "github.com/segmentio/analytics-go/v3"
+	"time"
+)
 
 // Holds the name and properties of an analytics event.
 type Event struct {
@@ -15,21 +19,33 @@ type Event struct {
 
 	// Custom properties of the event.
 	properties map[string]any
+
+	// Integrations
+	integrationsOverride optionals.Optional[segment.Integrations]
 }
 
-// Returns a new event with the given name and properties. The timestamp is set to the current time.
+// Returns a new event with the given name and properties.
+// The event is initialized with the current time as the timestamp.
 func NewEvent(distinctID string, name string, properties map[string]any) *Event {
 	return &Event{
-		distinctID: distinctID,
-		name:       name,
-		properties: properties,
-		timestamp:  time.Now(),
+		distinctID:           distinctID,
+		name:                 name,
+		properties:           properties,
+		timestamp:            time.Now(),
+		integrationsOverride: optionals.None[segment.Integrations](),
 	}
 }
 
 // Sets the event timestamp to the input time and returns the event.
 func (e *Event) SetTime(t time.Time) *Event {
 	e.timestamp = t
+	return e
+}
+
+// Sets the integrations that the event should be sent to.
+// This will override any default integrations set by the Analytics client.
+func (e *Event) SetIntegrations(integrations segment.Integrations) *Event {
+	e.integrationsOverride = optionals.Some(integrations)
 	return e
 }
 

--- a/analytics/event.go
+++ b/analytics/event.go
@@ -21,7 +21,7 @@ type Event struct {
 	properties map[string]any
 
 	// The integrations that the event should be sent to.
-	//This will override any default integrations passed to the Analytics client.
+	// This will override any default integrations passed to the Analytics client.
 	integrationsOverride optionals.Optional[segment.Integrations]
 }
 

--- a/analytics/event.go
+++ b/analytics/event.go
@@ -20,7 +20,8 @@ type Event struct {
 	// Custom properties of the event.
 	properties map[string]any
 
-	// Integrations
+	// The integrations that the event should be sent to.
+	//This will override any default integrations passed to the Analytics client.
 	integrationsOverride optionals.Optional[segment.Integrations]
 }
 


### PR DESCRIPTION
This adds the ability to configure which Segment destinations an analytics event will be sent to. 

The analytic client's config has been updated to accept a map of default integrations which will be used globally for all tracked events; these defaults can be overridden by calling an event's `SetIntegrations` method.