### PR TITLE
Tweak FiltersToMethods

### DIFF
--- a/spec_summary/filter_map_test.go
+++ b/spec_summary/filter_map_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/go-utils/optionals"
+	"github.com/akitasoftware/go-utils/sets"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,14 +14,15 @@ func TestFiltersToMethods(t *testing.T) {
 
 	m1 := akid.GenerateAPIMethodID().GetUUID().String()
 	m2 := akid.GenerateAPIMethodID().GetUUID().String()
+	ms := sets.NewSet(m1, m2)
 
 	fm.InsertNondirectionalFilter(HostFilter, "example.com", m1)
 	fm.InsertNondirectionalFilter(HostFilter, "example.com", m2)
-	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m1)
-	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m2)
+	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m1, ms)
+	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m2, ms)
 
-	fm.filterMap.Insert(HttpMethodFilter, "GET", m1)
-	fm.filterMap.Insert(HttpMethodFilter, "POST", m2)
+	fm.filterMap.Insert(HttpMethodFilter, "GET", optionals.Some(m1))
+	fm.filterMap.Insert(HttpMethodFilter, "POST", optionals.Some(m2))
 
 	// No filters.
 	directedSummary, numMethods := fm.SummarizeWithFilters(nil)

--- a/spec_summary/filter_map_test.go
+++ b/spec_summary/filter_map_test.go
@@ -14,12 +14,14 @@ func TestFiltersToMethods(t *testing.T) {
 
 	m1 := akid.GenerateAPIMethodID().GetUUID().String()
 	m2 := akid.GenerateAPIMethodID().GetUUID().String()
+	m3 := akid.GenerateAPIMethodID().GetUUID().String()
 	ms := sets.NewSet(m1, m2)
 
 	fm.InsertNondirectionalFilter(HostFilter, "example.com", m1)
 	fm.InsertNondirectionalFilter(HostFilter, "example.com", m2)
 	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m1, ms)
 	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m2, ms)
+	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "Basic", m3, ms)
 
 	fm.filterMap.Insert(HttpMethodFilter, "GET", optionals.Some(m1))
 	fm.filterMap.Insert(HttpMethodFilter, "POST", optionals.Some(m2))
@@ -31,6 +33,13 @@ func TestFiltersToMethods(t *testing.T) {
 	assert.Equal(t, 2, directedSummary.NondirectedFilters[HostFilter]["example.com"], "directed: example")
 	assert.Equal(t, 1, directedSummary.NondirectedFilters[HttpMethodFilter]["GET"], "directed: get")
 	assert.Equal(t, 2, directedSummary.DirectedFilters[RequestDirection][AuthFilter]["None"], "directed: auth")
+
+	basicCount, basicExists := directedSummary.DirectedFilters[RequestDirection][AuthFilter]["Basic"]
+	assert.Equal(t, 0, basicCount, "directed: basic")
+	assert.True(t, basicExists, "directed: basic")
+
+	_, bearerExists := directedSummary.DirectedFilters[RequestDirection][AuthFilter]["Bearer"]
+	assert.False(t, bearerExists, "directed: bearer")
 
 	summary := directedSummary.ToSummary()
 

--- a/spec_summary/summarize.go
+++ b/spec_summary/summarize.go
@@ -9,6 +9,7 @@ import (
 	"github.com/akitasoftware/akita-libs/spec_util"
 	. "github.com/akitasoftware/akita-libs/visitors"
 	vis "github.com/akitasoftware/akita-libs/visitors/http_rest"
+	"github.com/akitasoftware/go-utils/sets"
 	"github.com/akitasoftware/go-utils/slices"
 	"github.com/golang/glog"
 )
@@ -82,7 +83,7 @@ func (v *specSummaryVisitor) LeaveMethod(self interface{}, _ vis.SpecVisitorCont
 	// If this method has no authentications, increment Authentications["None"].
 	if v.methodSummary.DirectedFilters.GetCountsByValue(RequestDirection, AuthFilter) == nil {
 		v.summary.DirectedFilters.Increment(RequestDirection, AuthFilter, "None")
-		v.filtersToMethods.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m)
+		v.filtersToMethods.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m, sets.NewSet(m))
 	}
 
 	// For each term that occurs at least once in this method, increment the
@@ -97,7 +98,7 @@ func (v *specSummaryVisitor) LeaveMethod(self interface{}, _ vis.SpecVisitorCont
 	v.methodSummary.DirectedFilters.ForEach(func(direction Direction, kind FilterKind, value FilterValue, count int) bool {
 		if count > 0 {
 			v.summary.DirectedFilters.Increment(direction, kind, value)
-			v.filtersToMethods.InsertDirectionalFilter(direction, kind, value, m)
+			v.filtersToMethods.InsertDirectionalFilter(direction, kind, value, m, sets.NewSet(m))
 		}
 		return true
 	})


### PR DESCRIPTION
Support mapping filter values to empty sets. Allows us to track values that exist in a model, but have no matching methods because they've all been filtered out.