### PR TITLE
Tweak non-directional filters in FiltersToMethods

### DIFF
--- a/spec_summary/filter_map.go
+++ b/spec_summary/filter_map.go
@@ -2,7 +2,6 @@ package spec_summary
 
 import (
 	"github.com/akitasoftware/go-utils/optionals"
-	"github.com/akitasoftware/go-utils/sets"
 	. "github.com/akitasoftware/go-utils/sets"
 )
 
@@ -38,21 +37,16 @@ func NewFiltersToMethods[MethodID comparable]() *FiltersToMethods[MethodID] {
 }
 
 // Registers the given filter and value in the map. These are also associated
-// with the method ID if it exists in the given set of allowed methods.
-func (fm *FiltersToMethods[MethodID]) InsertNondirectionalFilter(filter FilterKind, value string, method MethodID, allowedMethods sets.Set[MethodID]) {
+// with the given method ID, if provided.
+func (fm *FiltersToMethods[MethodID]) InsertNondirectionalFilter(filter FilterKind, value string, method_opt optionals.Optional[MethodID]) {
 	if fm.filterMap == nil {
 		fm.filterMap = make(FilterMap[MethodID])
 	}
 
-	var method_opt optionals.Optional[MethodID]
-	if allowedMethods.Contains(method) {
-		method_opt = optionals.Some(method)
-	}
-
 	fm.filterMap.Insert(filter, value, method_opt)
 
-	// Register the method itself only when the method has not been filtered out.
-	if allowedMethods.Contains(method) {
+	// Register the method if one was given.
+	if method, exists := method_opt.Get(); exists {
 		if fm.allMethods == nil {
 			fm.allMethods = make(Set[MethodID])
 		}
@@ -61,21 +55,16 @@ func (fm *FiltersToMethods[MethodID]) InsertNondirectionalFilter(filter FilterKi
 }
 
 // Registers the given direction, filter, and value in the map. These are also
-// associated with the method ID, if it exists in the given set of allowed
-// methods.
-func (fm *FiltersToMethods[MethodID]) InsertDirectionalFilter(direction Direction, filter FilterKind, value string, method MethodID, allowedMethods sets.Set[MethodID]) {
+// associated with the given method ID, if provided.
+func (fm *FiltersToMethods[MethodID]) InsertDirectionalFilter(direction Direction, filter FilterKind, value string, method_opt optionals.Optional[MethodID]) {
 	if fm.filterMapByDirection == nil {
 		fm.filterMapByDirection = make(FilterMapByDirection[MethodID])
 	}
 
-	var method_opt optionals.Optional[MethodID]
-	if allowedMethods.Contains(method) {
-		method_opt = optionals.Some(method)
-	}
 	fm.filterMapByDirection.Insert(direction, filter, value, method_opt)
 
-	// Register the method itself only when the method has not been filtered out.
-	if allowedMethods.Contains(method) {
+	// Register the method if one was given.
+	if method, exists := method_opt.Get(); exists {
 		if fm.allMethods == nil {
 			fm.allMethods = make(Set[MethodID])
 		}

--- a/spec_summary/filter_map.go
+++ b/spec_summary/filter_map.go
@@ -37,18 +37,27 @@ func NewFiltersToMethods[MethodID comparable]() *FiltersToMethods[MethodID] {
 	}
 }
 
-// Registers the given method as having the given value for the given filter
-// kind.
-func (fm *FiltersToMethods[MethodID]) InsertNondirectionalFilter(filter FilterKind, value string, method MethodID) {
+// Registers the given filter and value in the map. These are also associated
+// with the method ID if it exists in the given set of allowed methods.
+func (fm *FiltersToMethods[MethodID]) InsertNondirectionalFilter(filter FilterKind, value string, method MethodID, allowedMethods sets.Set[MethodID]) {
 	if fm.filterMap == nil {
 		fm.filterMap = make(FilterMap[MethodID])
 	}
-	fm.filterMap.Insert(filter, value, optionals.Some(method))
 
-	if fm.allMethods == nil {
-		fm.allMethods = make(Set[MethodID])
+	var method_opt optionals.Optional[MethodID]
+	if allowedMethods.Contains(method) {
+		method_opt = optionals.Some(method)
 	}
-	fm.allMethods.Insert(method)
+
+	fm.filterMap.Insert(filter, value, method_opt)
+
+	// Register the method itself only when the method has not been filtered out.
+	if allowedMethods.Contains(method) {
+		if fm.allMethods == nil {
+			fm.allMethods = make(Set[MethodID])
+		}
+		fm.allMethods.Insert(method)
+	}
 }
 
 // Registers the given direction, filter, and value in the map. These are also

--- a/spec_summary/filter_map_test.go
+++ b/spec_summary/filter_map_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/go-utils/optionals"
-	"github.com/akitasoftware/go-utils/sets"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,15 +13,13 @@ func TestFiltersToMethods(t *testing.T) {
 
 	m1 := akid.GenerateAPIMethodID().GetUUID().String()
 	m2 := akid.GenerateAPIMethodID().GetUUID().String()
-	m3 := akid.GenerateAPIMethodID().GetUUID().String()
-	ms := sets.NewSet(m1, m2)
 
-	fm.InsertNondirectionalFilter(HostFilter, "example.com", m1, ms)
-	fm.InsertNondirectionalFilter(HostFilter, "example.com", m2, ms)
-	fm.InsertNondirectionalFilter(HostFilter, "example.org", m3, ms)
-	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m1, ms)
-	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m2, ms)
-	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "Basic", m3, ms)
+	fm.InsertNondirectionalFilter(HostFilter, "example.com", optionals.Some(m1))
+	fm.InsertNondirectionalFilter(HostFilter, "example.com", optionals.Some(m2))
+	fm.InsertNondirectionalFilter(HostFilter, "example.org", optionals.None[string]())
+	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", optionals.Some(m1))
+	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", optionals.Some(m2))
+	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "Basic", optionals.None[string]())
 
 	fm.filterMap.Insert(HttpMethodFilter, "GET", optionals.Some(m1))
 	fm.filterMap.Insert(HttpMethodFilter, "POST", optionals.Some(m2))

--- a/spec_summary/filter_map_test.go
+++ b/spec_summary/filter_map_test.go
@@ -17,8 +17,9 @@ func TestFiltersToMethods(t *testing.T) {
 	m3 := akid.GenerateAPIMethodID().GetUUID().String()
 	ms := sets.NewSet(m1, m2)
 
-	fm.InsertNondirectionalFilter(HostFilter, "example.com", m1)
-	fm.InsertNondirectionalFilter(HostFilter, "example.com", m2)
+	fm.InsertNondirectionalFilter(HostFilter, "example.com", m1, ms)
+	fm.InsertNondirectionalFilter(HostFilter, "example.com", m2, ms)
+	fm.InsertNondirectionalFilter(HostFilter, "example.org", m3, ms)
 	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m1, ms)
 	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m2, ms)
 	fm.InsertDirectionalFilter(RequestDirection, AuthFilter, "Basic", m3, ms)
@@ -33,6 +34,13 @@ func TestFiltersToMethods(t *testing.T) {
 	assert.Equal(t, 2, directedSummary.NondirectedFilters[HostFilter]["example.com"], "directed: example")
 	assert.Equal(t, 1, directedSummary.NondirectedFilters[HttpMethodFilter]["GET"], "directed: get")
 	assert.Equal(t, 2, directedSummary.DirectedFilters[RequestDirection][AuthFilter]["None"], "directed: auth")
+
+	exampleOrgCount, exampleOrgExists := directedSummary.NondirectedFilters[HostFilter]["example.org"]
+	assert.Equal(t, 0, exampleOrgCount, "directed: example.org")
+	assert.True(t, exampleOrgExists, "directed: example.org")
+
+	_, exampleNetExists := directedSummary.NondirectedFilters[HostFilter]["example.net"]
+	assert.False(t, exampleNetExists, "directed: example.net")
 
 	basicCount, basicExists := directedSummary.DirectedFilters[RequestDirection][AuthFilter]["Basic"]
 	assert.Equal(t, 0, basicCount, "directed: basic")

--- a/spec_summary/summarize.go
+++ b/spec_summary/summarize.go
@@ -9,7 +9,7 @@ import (
 	"github.com/akitasoftware/akita-libs/spec_util"
 	. "github.com/akitasoftware/akita-libs/visitors"
 	vis "github.com/akitasoftware/akita-libs/visitors/http_rest"
-	"github.com/akitasoftware/go-utils/sets"
+	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/akitasoftware/go-utils/slices"
 	"github.com/golang/glog"
 )
@@ -71,19 +71,19 @@ func (v *specSummaryVisitor) LeaveMethod(self interface{}, _ vis.SpecVisitorCont
 	if meta := spec_util.HTTPMetaFromMethod(m); meta != nil {
 		methodName := strings.ToUpper(meta.GetMethod())
 		v.summary.NondirectedFilters.Increment(HttpMethodFilter, methodName)
-		v.filtersToMethods.InsertNondirectionalFilter("http_methods", methodName, m, sets.NewSet(m))
+		v.filtersToMethods.InsertNondirectionalFilter("http_methods", methodName, optionals.Some(m))
 
 		v.summary.NondirectedFilters.Increment(PathFilter, meta.GetPathTemplate())
-		v.filtersToMethods.InsertNondirectionalFilter("paths", meta.GetPathTemplate(), m, sets.NewSet(m))
+		v.filtersToMethods.InsertNondirectionalFilter("paths", meta.GetPathTemplate(), optionals.Some(m))
 
 		v.summary.NondirectedFilters.Increment(HostFilter, meta.GetHost())
-		v.filtersToMethods.InsertNondirectionalFilter("hosts", meta.GetHost(), m, sets.NewSet(m))
+		v.filtersToMethods.InsertNondirectionalFilter("hosts", meta.GetHost(), optionals.Some(m))
 	}
 
 	// If this method has no authentications, increment Authentications["None"].
 	if v.methodSummary.DirectedFilters.GetCountsByValue(RequestDirection, AuthFilter) == nil {
 		v.summary.DirectedFilters.Increment(RequestDirection, AuthFilter, "None")
-		v.filtersToMethods.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", m, sets.NewSet(m))
+		v.filtersToMethods.InsertDirectionalFilter(RequestDirection, AuthFilter, "None", optionals.Some(m))
 	}
 
 	// For each term that occurs at least once in this method, increment the
@@ -91,14 +91,14 @@ func (v *specSummaryVisitor) LeaveMethod(self interface{}, _ vis.SpecVisitorCont
 	v.methodSummary.NondirectedFilters.ForEach(func(kind FilterKind, value FilterValue, count int) bool {
 		if count > 0 {
 			v.summary.NondirectedFilters.Increment(kind, value)
-			v.filtersToMethods.InsertNondirectionalFilter(kind, value, m, sets.NewSet(m))
+			v.filtersToMethods.InsertNondirectionalFilter(kind, value, optionals.Some(m))
 		}
 		return true
 	})
 	v.methodSummary.DirectedFilters.ForEach(func(direction Direction, kind FilterKind, value FilterValue, count int) bool {
 		if count > 0 {
 			v.summary.DirectedFilters.Increment(direction, kind, value)
-			v.filtersToMethods.InsertDirectionalFilter(direction, kind, value, m, sets.NewSet(m))
+			v.filtersToMethods.InsertDirectionalFilter(direction, kind, value, optionals.Some(m))
 		}
 		return true
 	})

--- a/spec_summary/summarize.go
+++ b/spec_summary/summarize.go
@@ -71,13 +71,13 @@ func (v *specSummaryVisitor) LeaveMethod(self interface{}, _ vis.SpecVisitorCont
 	if meta := spec_util.HTTPMetaFromMethod(m); meta != nil {
 		methodName := strings.ToUpper(meta.GetMethod())
 		v.summary.NondirectedFilters.Increment(HttpMethodFilter, methodName)
-		v.filtersToMethods.InsertNondirectionalFilter("http_methods", methodName, m)
+		v.filtersToMethods.InsertNondirectionalFilter("http_methods", methodName, m, sets.NewSet(m))
 
 		v.summary.NondirectedFilters.Increment(PathFilter, meta.GetPathTemplate())
-		v.filtersToMethods.InsertNondirectionalFilter("paths", meta.GetPathTemplate(), m)
+		v.filtersToMethods.InsertNondirectionalFilter("paths", meta.GetPathTemplate(), m, sets.NewSet(m))
 
 		v.summary.NondirectedFilters.Increment(HostFilter, meta.GetHost())
-		v.filtersToMethods.InsertNondirectionalFilter("hosts", meta.GetHost(), m)
+		v.filtersToMethods.InsertNondirectionalFilter("hosts", meta.GetHost(), m, sets.NewSet(m))
 	}
 
 	// If this method has no authentications, increment Authentications["None"].
@@ -91,7 +91,7 @@ func (v *specSummaryVisitor) LeaveMethod(self interface{}, _ vis.SpecVisitorCont
 	v.methodSummary.NondirectedFilters.ForEach(func(kind FilterKind, value FilterValue, count int) bool {
 		if count > 0 {
 			v.summary.NondirectedFilters.Increment(kind, value)
-			v.filtersToMethods.InsertNondirectionalFilter(kind, value, m)
+			v.filtersToMethods.InsertNondirectionalFilter(kind, value, m, sets.NewSet(m))
 		}
 		return true
 	})


### PR DESCRIPTION
Support mapping non-directional filter values to empty sets. Follows up on #168, which missed non-directional filters.