### PR TITLE
Distinguish nullable from optional fields

### DIFF
--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -202,9 +202,13 @@ type melder struct {
 //   - At most one variant in the OneOf is a list.
 //   - All other variants in the OneOf is a primitive.
 //
+// If the given src and dst have the following invariant on all OneOfs and
+// Optionals, then this is preserved.
+//
+//   - If any children are nullable, then the nullable bit is set on
+//     the parent, not the children.
+//
 // Assumes that dst.Meta == src.Meta.
-//
-//
 //
 // XXX: In some cases, this modifies src as well as dst :/
 func (m *melder) meldData(dst, src *pb.Data) (retErr error) {

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -690,21 +690,18 @@ func (m *melder) meldOneOf(dst, src *pb.OneOf) error {
 
 // Melds a variant into a one-of.
 func (m *melder) meldOneOfVariant(dst *pb.OneOf, srcHash *string, srcVariant *pb.Data) error {
-	// Make sure the meta field of srcVariant is cleared. For HTTP specs, OneOf
+	// Make sure the meta and nullable fields of srcVariant are cleared. For HTTP specs, OneOf
 	// variants all have the same metadata, recorded in the Data.Meta field of the
-	// containing Data.
-	if srcVariant.Meta != nil {
+	// containing Data.  The nullable bit was copied to the dst Data object in meldData
+	// before calling meldOneOfVariant.
+	if srcVariant.Meta != nil || srcVariant.Nullable {
 		srcVariant = proto.Clone(srcVariant).(*pb.Data)
 		srcVariant.Meta = nil
+		srcVariant.Nullable = false
 
 		// We'll recompute the hash.
 		srcHash = nil
 	}
-
-	// Clear the nullable bit from srcVariant.  The nullable bit was
-	// copied to the dst Data object in meldData before calling
-	// meldOneOfVariant.
-	srcVariant.Nullable = false
 
 	// Hash if needed.
 	if srcHash == nil {

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -261,7 +261,7 @@ var tests = []testData{
 			"testdata/meld/meld_map_3.pb.txt",
 		},
 		MeldOptions{},
-		"testdata/meld/meld_map_1_map_2_expected.pb.txt",
+		"testdata/meld/meld_map_1_map_3_expected.pb.txt",
 	},
 	{
 		"structs with number fields",
@@ -291,6 +291,15 @@ var tests = []testData{
 		},
 		MeldOptions{},
 		"testdata/meld/meld_optional_none_expected.pb.txt",
+	},
+	{
+		"test meld(oneof<T1, T2>, nullable<T1>) => nullable<oneof<T1, T2>>",
+		[]string{
+			"testdata/meld/meld_oneof_with_nullable_primitive_1.pb.txt",
+			"testdata/meld/meld_oneof_with_nullable_primitive_2.pb.txt",
+		},
+		MeldOptions{},
+		"testdata/meld/meld_oneof_with_nullable_primitive_expected.pb.txt",
 	},
 }
 

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
+
 	"github.com/akitasoftware/akita-libs/test"
 )
 
@@ -79,7 +80,7 @@ var tests = []testData{
 		"testdata/meld/meld_with_existing_conflict_expected.pb.txt",
 	},
 	{
-		"turn conflict with none into optional - order 1",
+		"turn conflict with none into nullable - order 1",
 		[]string{
 			"testdata/meld/meld_suppress_none_conflict_1.pb.txt",
 			"testdata/meld/meld_suppress_none_conflict_2.pb.txt",
@@ -270,6 +271,26 @@ var tests = []testData{
 		},
 		MeldOptions{},
 		"testdata/meld/meld_map_4_map_5_expected.pb.txt",
+	},
+	{
+		// Test meld(T, nullable<T>) => nullable<T>
+		"meld nullable and non-nullable versions of the same type",
+		[]string{
+			"testdata/meld/meld_nullable_1.pb.txt",
+			"testdata/meld/meld_nullable_2.pb.txt",
+		},
+		MeldOptions{},
+		"testdata/meld/meld_nullable_expected.pb.txt",
+	},
+	{
+		// Test meld(None, optional<T>) => nullable<optional<T>>
+		"meld none and optional string should be nullable optional string",
+		[]string{
+			"testdata/meld/meld_optional_none_1.pb.txt",
+			"testdata/meld/meld_optional_none_2.pb.txt",
+		},
+		MeldOptions{},
+		"testdata/meld/meld_optional_none_expected.pb.txt",
 	},
 }
 

--- a/spec_util/testdata/meld/meld_map_1_map_3_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_map_1_map_3_expected.pb.txt
@@ -1,0 +1,44 @@
+# api_spec.Witness proto
+
+method <
+  id: <
+    api_type: HTTP_REST
+  >
+  responses: <
+    key: "il-kmAwcSWw="
+    value: <
+      struct: <
+        map_type: <
+          key: <
+            primitive: <
+              string_value: <
+              >
+            >
+          >
+          value: <
+            nullable: true
+            primitive: <
+              string_value: <
+              >
+            >
+          >
+        >
+      >
+      meta: <
+        http: <
+          body: <
+            content_type: JSON
+          >
+          response_code: 200
+        >
+      >
+    >
+  >
+  meta: <
+    http: <
+      method: "GET"
+      path_template: "/t1"
+      host: "kafka"
+    >
+  >
+>

--- a/spec_util/testdata/meld/meld_nullable_1.pb.txt
+++ b/spec_util/testdata/meld/meld_nullable_1.pb.txt
@@ -18,6 +18,15 @@ method {
           }
         }
         fields {
+          key: "left_present_right_not_present"
+          value {
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
           key: "left_present_right_none"
           value {
             primitive {
@@ -46,6 +55,16 @@ method {
           }
         }
         fields {
+          key: "left_nullable_right_not_present"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
           key: "left_nullable_right_none"
           value {
             nullable: true
@@ -64,10 +83,31 @@ method {
           }
         }
         fields {
+          key: "left_none_right_not_present"
+          value {
+            optional {
+              none {}
+            }
+          }
+        }
+        fields {
           key: "left_none_right_nullable"
           value {
             optional {
               none {}
+            }
+          }
+        }
+        fields {
+          key: "left_optional_string_right_nullable_string"
+          value {
+            optional {
+              data {
+                primitive {
+                  string_value {
+                  }
+                }
+              }
             }
           }
         }

--- a/spec_util/testdata/meld/meld_nullable_1.pb.txt
+++ b/spec_util/testdata/meld/meld_nullable_1.pb.txt
@@ -1,0 +1,92 @@
+# api_spec.Witness proto
+
+method {
+  id {
+    api_type: HTTP_REST
+  }
+  responses {
+    key: "FiNRlcJh7SI="
+    value {
+      struct {
+        fields {
+          key: "left_present_right_present"
+          value {
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_present_right_none"
+          value {
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_present_right_nullable"
+          value {
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_nullable_right_present"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_nullable_right_none"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_none_right_present"
+          value {
+            optional {
+              none {}
+            }
+          }
+        }
+        fields {
+          key: "left_none_right_nullable"
+          value {
+            optional {
+              none {}
+            }
+          }
+        }
+      }
+      meta {
+        http {
+          body {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+  meta {
+    http {
+      method: "GET"
+      path_template: "/t1"
+      host: "kafka"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_nullable_2.pb.txt
+++ b/spec_util/testdata/meld/meld_nullable_2.pb.txt
@@ -1,0 +1,92 @@
+# api_spec.Witness proto
+
+method {
+  id {
+    api_type: HTTP_REST
+  }
+  responses {
+    key: "FiNRlcJh7SI="
+    value {
+      struct {
+        fields {
+          key: "left_present_right_present"
+          value {
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_present_right_none"
+          value {
+            optional {
+              none {}
+            }
+          }
+        }
+        fields {
+          key: "left_present_right_nullable"
+          value {
+            nullable: true
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_nullable_right_present"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_nullable_right_none"
+          value {
+            optional {
+              none {}
+            }
+          }
+        }
+        fields {
+          key: "left_none_right_present"
+          value {
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_none_right_nullable"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+      }
+      meta {
+        http {
+          body {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+  meta {
+    http {
+      method: "GET"
+      path_template: "/t1"
+      host: "kafka"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_nullable_2.pb.txt
+++ b/spec_util/testdata/meld/meld_nullable_2.pb.txt
@@ -71,6 +71,16 @@ method {
             }
           }
         }
+        fields {
+          key: "left_optional_string_right_nullable_string"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
       }
       meta {
         http {

--- a/spec_util/testdata/meld/meld_nullable_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_nullable_expected.pb.txt
@@ -5,7 +5,7 @@ method {
     api_type: HTTP_REST
   }
   responses {
-    key: "cbT4JSrOsvE="
+    key: "YGcK4tB-s6I="
     value {
       struct {
         fields {
@@ -13,6 +13,19 @@ method {
           value {
             primitive {
               int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_present_right_not_present"
+          value {
+            optional: {
+              data: {
+                primitive {
+                  int64_value {
+                  }
+                }
               }
             }
           }
@@ -48,6 +61,20 @@ method {
           }
         }
         fields {
+          key: "left_nullable_right_not_present"
+          value {
+            nullable: true
+            optional {
+              data: {
+                primitive {
+                  string_value {
+                  }
+                }
+              }
+            }
+          }
+        }
+        fields {
           key: "left_nullable_right_none"
           value {
             nullable: true
@@ -68,11 +95,38 @@ method {
           }
         }
         fields {
+          key: "left_none_right_not_present"
+          value {
+            nullable: true
+            optional: {
+              data: {
+                optional: {
+                  none: {}
+                }
+              }
+            }
+          }
+        }
+        fields {
           key: "left_none_right_nullable"
           value {
             nullable: true
             primitive {
               string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_optional_string_right_nullable_string"
+          value {
+            nullable: true
+            optional {
+              data {
+                primitive {
+                  string_value {
+                  }
+                }
               }
             }
           }

--- a/spec_util/testdata/meld/meld_nullable_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_nullable_expected.pb.txt
@@ -1,0 +1,98 @@
+# api_spec.Witness proto
+
+method {
+  id {
+    api_type: HTTP_REST
+  }
+  responses {
+    key: "cbT4JSrOsvE="
+    value {
+      struct {
+        fields {
+          key: "left_present_right_present"
+          value {
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_present_right_none"
+          value {
+            nullable: true
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_present_right_nullable"
+          value {
+            nullable: true
+            primitive {
+              int64_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_nullable_right_present"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_nullable_right_none"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_none_right_present"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+        fields {
+          key: "left_none_right_nullable"
+          value {
+            nullable: true
+            primitive {
+              string_value {
+              }
+            }
+          }
+        }
+      }
+      meta {
+        http {
+          body {
+            content_type: JSON
+          }
+          response_code: 200
+        }
+      }
+    }
+  }
+  meta {
+    http {
+      method: "GET"
+      path_template: "/t1"
+      host: "kafka"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_oneof_with_nullable_primitive_1.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_nullable_primitive_1.pb.txt
@@ -1,0 +1,66 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"6JrDs8poHbU="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            oneof: {
+              options: {
+                key:"H--6VaA31gw="
+                value: {
+                  primitive: {
+                    string_value: {
+                      value:"2020-01"
+                    }
+                    formats: {
+                      key:"ISOYearMonth"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "tyPWfpWnavU="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {
+                            value: "file_1"
+                          }
+                          formats: {
+                            key: "ISOYearMonth"
+                            value: true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_oneof_with_nullable_primitive_2.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_nullable_primitive_2.pb.txt
@@ -1,0 +1,39 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"6JrDs8poHbU="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            nullable: true
+            primitive: {
+              int32_value: {
+                value:20200101
+              }
+              formats: {
+                key:"ISOYearMonthDay"
+                value:true
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_oneof_with_nullable_primitive_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_oneof_with_nullable_primitive_expected.pb.txt
@@ -1,0 +1,81 @@
+# api_spec.Witness proto
+
+method: {
+  responses: {
+    key:"LKUpABrY8bk="
+    value: {
+      struct: {
+        fields: {
+          key:"name"
+          value: {
+            nullable: true
+            oneof: {
+              options: {
+                key:"H--6VaA31gw="
+                value: {
+                  primitive: {
+                    string_value: {
+                      value:"2020-01"
+                    }
+                    formats: {
+                      key:"ISOYearMonth"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key:"PGYGe9fHTG4="
+                value: {
+                  primitive: {
+                    int32_value: {
+                      value:20200101
+                    }
+                    formats: {
+                      key:"ISOYearMonthDay"
+                      value:true
+                    }
+                  }
+                }
+              }
+              options: {
+                key: "tyPWfpWnavU="
+                value: {
+                  struct: {
+                    fields: {
+                      key: "name"
+                      value: {
+                        primitive: {
+                          string_value: {
+                            value: "file_1"
+                          }
+                          formats: {
+                            key: "ISOYearMonth"
+                            value: true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      meta: {
+        http: {
+          body: {
+            content_type:JSON
+          }
+          response_code:200
+        }
+      }
+    }
+  }
+  meta: {
+    http: {
+      method:"POST" path_template:"/api/create_file" host:"www.akibox.com"
+    }
+  }
+}

--- a/spec_util/testdata/meld/meld_optional_none_1.pb.txt
+++ b/spec_util/testdata/meld/meld_optional_none_1.pb.txt
@@ -9,16 +9,17 @@ method: {
     }
   }
   responses: {
-    key: "-jQpCVnqeTk="
+    key: "naAThnYPT5A="
     value: {
       struct: {
         fields: {
           key: "name"
           value: {
-            nullable: true
-            primitive: {
-              string_value: {
-                value: "foo"
+            optional: {
+              data: {
+                primitive: {
+                  string_value: {}
+                }
               }
             }
           }

--- a/spec_util/testdata/meld/meld_optional_none_2.pb.txt
+++ b/spec_util/testdata/meld/meld_optional_none_2.pb.txt
@@ -9,17 +9,14 @@ method: {
     }
   }
   responses: {
-    key: "-jQpCVnqeTk="
+    key: "naAThnYPT5A="
     value: {
       struct: {
         fields: {
           key: "name"
           value: {
-            nullable: true
-            primitive: {
-              string_value: {
-                value: "foo"
-              }
+            optional: {
+              none: {}
             }
           }
         }

--- a/spec_util/testdata/meld/meld_optional_none_expected.pb.txt
+++ b/spec_util/testdata/meld/meld_optional_none_expected.pb.txt
@@ -9,16 +9,18 @@ method: {
     }
   }
   responses: {
-    key: "-jQpCVnqeTk="
+    key: "75O6NQ_g5Io="
     value: {
       struct: {
         fields: {
           key: "name"
           value: {
             nullable: true
-            primitive: {
-              string_value: {
-                value: "foo"
+            optional: {
+              data: {
+                primitive: {
+                  string_value: {}
+                }
               }
             }
           }


### PR DESCRIPTION
The Akita IR has an Optional node that is either Data (the field with this type is optional, i.e. may be present or absent) or None (the field with this type has only been seen with "null" as a value).

The Data node also has a "nullable" property, which indicates that a field with this type is capable of carrying "null" as a value.

Previously, we were treating the None node as optional, rather than nullable. That is, `meld(None, T) = Optional<T>`.  This PR fixes that, changing melding so that `meld(None, T) = Nullable<T>` where `Nullable<T>` means that `T.nullable = true`.

It also propagates `Data.nullable` during melding.