### PR TITLE
Schema for initial client telemetry

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -511,6 +511,27 @@ type PostClientPacketCaptureStatsRequest struct {
 	ApidumpErrorText string           `json:"apidump_error_text,omitempty"`
 }
 
+type PostInitialClientTelemetry struct {
+	ClientID                  akid.ClientID `json:"client_id"`
+	ObservedStartingAt        time.Time     `json:"observed_starting_at"`
+	ObservedDurationInSeconds int           `json:"observed_duration_in_seconds"`
+
+	// Report on any errors encounted during apidump that should be shown to the user.
+	ApidumpError     ApidumpErrorType `json:"apidump_error,omitempty"`
+	ApidumpErrorText string           `json:"apidump_error_text,omitempty"`
+
+	CLIVersion    string `json:"cli_version"`
+	CLITargetArch string `json:"cli_target_arch"`
+
+	// True when the CLI is running in a Docker container we distributed, e.g.
+	// akitasoftware/cli:latest.
+	AkitaDockerRelease bool `json:"akita_docker_release"`
+
+	// True when the host.docker.internal DNS name resolves, which indicates the
+	// CLI is running in a docker container hosted on Docker Desktop.
+	DockerDesktop bool `json:"docker_desktop"`
+}
+
 type UserResponse struct {
 	ID             akid.UserID         `json:"id"`
 	OrganizationID akid.OrganizationID `json:"organization_id"`

--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -519,8 +519,8 @@ type PostInitialClientTelemetryRequest struct {
 	CLIVersion    string `json:"cli_version"`
 	CLITargetArch string `json:"cli_target_arch"`
 
-	// True when the CLI is running in a Docker container we distributed, e.g.
-	// akitasoftware/cli:latest.
+	// True when the CLI is running in a Docker container distributed by Akita,
+	// e.g. akitasoftware/cli:latest on Docker Hub.
 	AkitaDockerRelease bool `json:"akita_docker_release"`
 
 	// True when the host.docker.internal DNS name resolves, which indicates the

--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -511,7 +511,7 @@ type PostClientPacketCaptureStatsRequest struct {
 	ApidumpErrorText string           `json:"apidump_error_text,omitempty"`
 }
 
-type PostInitialClientTelemetry struct {
+type PostInitialClientTelemetryRequest struct {
 	ClientID                  akid.ClientID `json:"client_id"`
 	ObservedStartingAt        time.Time     `json:"observed_starting_at"`
 	ObservedDurationInSeconds int           `json:"observed_duration_in_seconds"`

--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -516,10 +516,6 @@ type PostInitialClientTelemetry struct {
 	ObservedStartingAt        time.Time     `json:"observed_starting_at"`
 	ObservedDurationInSeconds int           `json:"observed_duration_in_seconds"`
 
-	// Report on any errors encounted during apidump that should be shown to the user.
-	ApidumpError     ApidumpErrorType `json:"apidump_error,omitempty"`
-	ApidumpErrorText string           `json:"apidump_error_text,omitempty"`
-
 	CLIVersion    string `json:"cli_version"`
 	CLITargetArch string `json:"cli_target_arch"`
 


### PR DESCRIPTION
Adds a new request type for uploading initial telemetry and metadata when the Akita CLI first starts.