### PR TITLE
Factor EndpointGroupAttributes

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -377,6 +377,18 @@ const (
 
 )
 
+// Describes a group of endpoints. If a non-empty string is provided for any
+// attribute in this struct, then all endpoints in the group will have that
+// value for that attribute.
+//
+// XXX Would be nice for this to just be map[attribute]string, but then we
+// wouldn't be able to use this as a map key.
+type EndpointGroup struct {
+	Method       string `json:"method,omitempty"`
+	Host         string `json:"host,omitempty"`
+	PathTemplate string `json:"path_template,omitempty"`
+}
+
 // Describes a common set of attributes for a group of endpoints. If a
 // non-default value (i.e., non-empty string or non-zero int) is provided for
 // any attribute in this struct, then all endpoints in the group will have that
@@ -385,10 +397,8 @@ const (
 // XXX Would be nice for this to just be map[attribute]string, but then we
 // wouldn't be able to use this as a map key.
 type EndpointGroupAttributes struct {
-	Method       string `json:"method,omitempty"`
-	Host         string `json:"host,omitempty"`
-	PathTemplate string `json:"path_template,omitempty"`
-	ResponseCode int    `json:"response_code,omitempty"`
+	EndpointGroup
+	ResponseCode int `json:"response_code,omitempty"`
 }
 
 type Timeline struct {


### PR DESCRIPTION
Broke out the endpoint part of `EndpointGroupAttributes` into `EndpointGroup`.