### PR TITLE
Include trace start and end time in metadata response

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -230,6 +230,10 @@ type GetSpecMetadataResponse struct {
 	// per tag.
 	Tags    tags.SingletonTags `json:"tags,omitempty"`
 	TagsSet tags.Tags          `json:"tags_set,omitempty"`
+
+	// Deployment times
+	TraceStartTime *time.Time `json:"trace_start_time,omitempty"`
+	TraceEndTime   *time.Time `json:"trace_end_time,omitempty"`
 }
 
 type GetSpecResponse struct {


### PR DESCRIPTION
`GET /services/{projectID}/specs/{modelID}/metadata` currently doesn't include the trace start and end times, which are needed for displaying the time range that a model covers (and lining up graphs to it).

I copied over the extra properties from the `SpecInfo` struct, which is used when listing specs/models. Let me know if I did this wrong!