### PR TITLE
Fix melding of one-ofs with primitives

### DIFF
--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -614,6 +614,30 @@ func TestMeldData(t *testing.T) {
 				PotentialConflict: true,
 			}),
 		},
+		{
+			name: "merging oneof with unformatted primitive",
+			left: wrapOneOf(&pb.OneOf{
+				Options: map[string]*pb.Data{
+					"1": wrapPrim(&pb.Primitive{
+						Value:      &pb.Primitive_Uint32Value{Uint32Value: &pb.Uint32{}},
+						FormatKind: "datetime",
+						Formats:    map[string]bool{"timestamp_seconds_since_epoch": true},
+					}),
+					"2": wrapPrim(&pb.Primitive{
+						Value:      &pb.Primitive_Uint64Value{Uint64Value: &pb.Uint64{}},
+						FormatKind: "unique_id",
+						Formats:    map[string]bool{"integer_id": true},
+					}),
+				},
+				PotentialConflict: true,
+			}),
+			right: wrapPrim(&pb.Primitive{
+				Value: &pb.Primitive_Uint32Value{Uint32Value: &pb.Uint32{}},
+			}),
+			expected: wrapPrim(&pb.Primitive{
+				Value: &pb.Primitive_Uint64Value{Uint64Value: &pb.Uint64{}},
+			}),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -615,7 +615,7 @@ func TestMeldData(t *testing.T) {
 			}),
 		},
 		{
-			name: "merging oneof with unformatted primitive",
+			name: "merging oneof with unformatted primitive - resulting in a primitive",
 			left: wrapOneOf(&pb.OneOf{
 				Options: map[string]*pb.Data{
 					"1": wrapPrim(&pb.Primitive{
@@ -636,6 +636,45 @@ func TestMeldData(t *testing.T) {
 			}),
 			expected: wrapPrim(&pb.Primitive{
 				Value: &pb.Primitive_Uint64Value{Uint64Value: &pb.Uint64{}},
+			}),
+		},
+		{
+			name: "merging oneof with unformatted primitive - resulting in a oneof",
+			left: wrapOneOf(&pb.OneOf{
+				Options: map[string]*pb.Data{
+					"1": wrapPrim(&pb.Primitive{
+						Value:      &pb.Primitive_Uint32Value{Uint32Value: &pb.Uint32{}},
+						FormatKind: "datetime",
+						Formats:    map[string]bool{"timestamp_seconds_since_epoch": true},
+					}),
+					"2": wrapPrim(&pb.Primitive{
+						Value:      &pb.Primitive_Uint64Value{Uint64Value: &pb.Uint64{}},
+						FormatKind: "unique_id",
+						Formats:    map[string]bool{"integer_id": true},
+					}),
+					"3": wrapPrim(&pb.Primitive{
+						Value:      &pb.Primitive_StringValue{StringValue: &pb.String{}},
+						FormatKind: "currency_name",
+						Formats:    map[string]bool{"currency_abbreviation": true},
+					}),
+				},
+				PotentialConflict: true,
+			}),
+			right: wrapPrim(&pb.Primitive{
+				Value: &pb.Primitive_Uint32Value{Uint32Value: &pb.Uint32{}},
+			}),
+			expected: wrapOneOf(&pb.OneOf{
+				Options: map[string]*pb.Data{
+					"va5tP-fnZF8=": wrapPrim(&pb.Primitive{
+						Value: &pb.Primitive_Uint64Value{Uint64Value: &pb.Uint64{}},
+					}),
+					"3": wrapPrim(&pb.Primitive{
+						Value:      &pb.Primitive_StringValue{StringValue: &pb.String{}},
+						FormatKind: "currency_name",
+						Formats:    map[string]bool{"currency_abbreviation": true},
+					}),
+				},
+				PotentialConflict: true,
 			}),
 		},
 	}


### PR DESCRIPTION
When melding a primitive into a one-of, we need to meld against all compatible variants in the one-of, not just the first one we find. This allows the meld to collapse several variants into one, if the primitive has no formats.