### PR TITLE
Add explicit types for hosts and endpoint paths

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -6,6 +6,8 @@ import (
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/client_telemetry"
+	"github.com/akitasoftware/akita-libs/endpoints"
+	"github.com/akitasoftware/akita-libs/http_rest_methods"
 	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/akita-libs/time_span"
 )
@@ -379,16 +381,13 @@ const (
 
 )
 
-// Describes a group of endpoints. If a non-empty string is provided for any
+// Describes a group of endpoints. If a non-default value is provided for any
 // attribute in this struct, then all endpoints in the group will have that
 // value for that attribute.
-//
-// XXX Would be nice for this to just be map[attribute]string, but then we
-// wouldn't be able to use this as a map key.
 type EndpointGroup struct {
-	Method       string `json:"method,omitempty"`
-	Host         string `json:"host,omitempty"`
-	PathTemplate string `json:"path_template,omitempty"`
+	Method       http_rest_methods.HTTPMethod `json:"method,omitempty"`
+	Host         endpoints.Host               `json:"host,omitempty"`
+	PathTemplate endpoints.PathTemplate       `json:"path_template,omitempty"`
 }
 
 // Describes a common set of attributes for a group of endpoints. If a

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -1,0 +1,10 @@
+package endpoints
+
+import "github.com/akitasoftware/akita-libs/http_rest_methods"
+
+// An endpoint whose host and path template have not been normalized.
+type Endpoint struct {
+	HTTPMethod   http_rest_methods.HTTPMethod `json:"method"`
+	Host         Host                         `json:"host"`
+	PathTemplate PathTemplate                 `json:"path_template"`
+}

--- a/endpoints/hosts.go
+++ b/endpoints/hosts.go
@@ -1,0 +1,23 @@
+package endpoints
+
+import (
+	"strconv"
+	"strings"
+)
+
+// A host that has not been normalized. Hosts are hostnames and an optional port
+// number. For example, "api.akitasoftware.com" or "kings-cross:50060".
+type Host string
+
+func (host Host) HasPort(port uint16) bool {
+	suffix := ":" + strconv.FormatUint(uint64(port), 10)
+	return strings.HasSuffix(string(host), suffix)
+}
+
+func (host Host) String() string {
+	return string(host)
+}
+
+func CompareHosts(h1, h2 Host) int {
+	return strings.Compare(h1.String(), h2.String())
+}

--- a/endpoints/path_templates.go
+++ b/endpoints/path_templates.go
@@ -1,0 +1,16 @@
+package endpoints
+
+import "strings"
+
+// A path template whose parameter names have not been normalized.
+type PathTemplate string
+
+// Splits the path template into its path components. For example,
+// "/v1/{foo}/bar".GetComponents() returns {"", "v1", "{foo}", "bar"}.
+func (p PathTemplate) GetComponents() []string {
+	return strings.Split(string(p), "/")
+}
+
+func (p PathTemplate) String() string {
+	return string(p)
+}

--- a/http_rest_methods/methods.go
+++ b/http_rest_methods/methods.go
@@ -1,0 +1,65 @@
+package http_rest_methods
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/akitasoftware/go-utils/sets"
+	"github.com/pkg/errors"
+)
+
+type HTTPMethod string
+
+const (
+	CONNECT HTTPMethod = "CONNECT"
+	DELETE  HTTPMethod = "DELETE"
+	GET     HTTPMethod = "GET"
+	HEAD    HTTPMethod = "HEAD"
+	OPTIONS HTTPMethod = "OPTIONS"
+	PATCH   HTTPMethod = "PATCH"
+	POST    HTTPMethod = "POST"
+	PUT     HTTPMethod = "PUT"
+	TRACE   HTTPMethod = "TRACE"
+)
+
+var AllMethods = sets.NewSet(
+	CONNECT,
+	DELETE,
+	GET,
+	HEAD,
+	OPTIONS,
+	PATCH,
+	POST,
+	PUT,
+	TRACE,
+)
+
+func (m HTTPMethod) String() string {
+	return string(m)
+}
+
+func CompareHTTPMethods(m1, m2 HTTPMethod) int {
+	return strings.Compare(m1.String(), m2.String())
+}
+
+func (m *HTTPMethod) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	var err error
+	if *m, err = ParseHTTPMethod(s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ParseHTTPMethod(s string) (HTTPMethod, error) {
+	result := HTTPMethod(strings.ToUpper(s))
+	if AllMethods.Contains(result) {
+		return result, nil
+	}
+
+	return "", errors.Errorf("unknown rest method: %s", s)
+}


### PR DESCRIPTION
Introduced an `Endpoint` type for representing REST endpoints, and its components: `HTTPMethod`, `Host`, and `PathTemplate`. Modified `EndpointGroup` so that it also uses these types.