### PR TITLE
Support for larger, random sampling of path arguments

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
-github.com/akitasoftware/go-utils v0.0.0-20220521045242-cabe4c63daed h1:34LDOf+9xIFY3Tv0bgSR4b6CQuOEfLn/G6g5tCKjMaw=
-github.com/akitasoftware/go-utils v0.0.0-20220521045242-cabe4c63daed/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d h1:pN1dbNacZ/mvlU1NcJVDxqmKnrDQDTVaN6iKOarfdYM=
 github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/spec_util/infer_maps.go
+++ b/spec_util/infer_maps.go
@@ -77,7 +77,7 @@ type structToMapVisitor struct {
 var _ http_rest.DefaultSpecVisitor = (*structToMapVisitor)(nil)
 
 func newStructToMapVisitor() *structToMapVisitor {
-	return &structToMapVisitor{melder: melder{mergeTracking: true}}
+	return &structToMapVisitor{melder: melder{}}
 }
 
 func (v *structToMapVisitor) EnterStruct(self interface{}, c http_rest.SpecVisitorContext, s *pb.Struct) visitors.Cont {

--- a/spec_util/infer_maps.go
+++ b/spec_util/infer_maps.go
@@ -71,13 +71,13 @@ func startsWithNumber(s string) bool {
 
 type structToMapVisitor struct {
 	http_rest.DefaultSpecVisitorImpl
-	melder melder
+	melder Melder
 }
 
 var _ http_rest.DefaultSpecVisitor = (*structToMapVisitor)(nil)
 
 func newStructToMapVisitor() *structToMapVisitor {
-	return &structToMapVisitor{melder: melder{}}
+	return &structToMapVisitor{melder: Melder{}}
 }
 
 func (v *structToMapVisitor) EnterStruct(self interface{}, c http_rest.SpecVisitorContext, s *pb.Struct) visitors.Cont {

--- a/spec_util/meld.go
+++ b/spec_util/meld.go
@@ -132,7 +132,7 @@ func (m *Melder) mergeExampleValues(dst, src *pb.Data) {
 		// have configured.
 		maxExamples = m.opts.MaxNumPathParamExampleValues.GetOrDefault(2)
 
-		if m.opts.KeepRandomPathParamExampleValues {
+		if m.opts.KeepRandomPathParamExampleValues.GetOrDefault(false) {
 			sortValues = func(values []string) {
 				rand.Shuffle(len(values), func(i, j int) {
 					values[i], values[j] = values[j], values[i]

--- a/spec_util/meld_test.go
+++ b/spec_util/meld_test.go
@@ -558,9 +558,11 @@ func TestMeldPrimitives(t *testing.T) {
 		},
 	}
 
+	melder := NewMelder(MeldOptions{})
+
 	for _, tc := range testCases {
 		leftDst := wrapPrim(proto.Clone(tc.left).(*pb.Primitive))
-		err := MeldData(leftDst, wrapPrim(tc.right))
+		err := melder.MeldData(leftDst, wrapPrim(tc.right))
 		assert.NoError(t, err, "[%s] failed to meld", tc.name)
 
 		if diff := cmp.Diff(tc.expected, leftDst, cmpWitnessOptions...); diff != "" {
@@ -568,7 +570,7 @@ func TestMeldPrimitives(t *testing.T) {
 		}
 
 		rightDst := wrapPrim(proto.Clone(tc.right).(*pb.Primitive))
-		err = MeldData(rightDst, wrapPrim(tc.left))
+		err = melder.MeldData(rightDst, wrapPrim(tc.left))
 		assert.NoError(t, err, "[%s] failed to meld", tc.name)
 
 		if diff := cmp.Diff(tc.expected, rightDst, cmpWitnessOptions...); diff != "" {
@@ -726,10 +728,12 @@ func TestMeldData(t *testing.T) {
 		},
 	}
 
+	melder := NewMelder(MeldOptions{})
+
 	for _, tc := range testCases {
 		leftDst := proto.Clone(tc.left).(*pb.Data)
 		right := proto.Clone(tc.right).(*pb.Data)
-		err := MeldData(leftDst, right)
+		err := melder.MeldData(leftDst, right)
 		assert.NoError(t, err, "[%s] failed to meld", tc.name)
 
 		if diff := cmp.Diff(tc.expected, leftDst, cmpWitnessOptions...); diff != "" {
@@ -738,7 +742,7 @@ func TestMeldData(t *testing.T) {
 
 		rightDst := proto.Clone(tc.right).(*pb.Data)
 		left := proto.Clone(tc.left).(*pb.Data)
-		err = MeldData(rightDst, left)
+		err = melder.MeldData(rightDst, left)
 		assert.NoError(t, err, "[%s] failed to meld", tc.name)
 
 		if diff := cmp.Diff(tc.expected, rightDst, cmpWitnessOptions...); diff != "" {

--- a/spec_util/melded_method.go
+++ b/spec_util/melded_method.go
@@ -119,7 +119,7 @@ type MeldOptions struct {
 
 	// Controls whether the examples kept for each path parameter are sampled at
 	// random.
-	KeepRandomPathParamExampleValues bool
+	KeepRandomPathParamExampleValues optionals.Optional[bool]
 }
 
 // Determines whether a given method has only 4xx response codes. Returns true if the method has at least one response and all response codes are 4xx.

--- a/spec_util/melded_method.go
+++ b/spec_util/melded_method.go
@@ -112,6 +112,14 @@ type MeldOptions struct {
 	// Controls the maximum number of cookies that may be present in a meld
 	// result. Any extra cookies are discarded.
 	MaxNumCookies optionals.Optional[int]
+
+	// Controls the maximum number of examples that are kept for each path
+	// parameter.
+	MaxNumPathParamExampleValues optionals.Optional[int]
+
+	// Controls whether the examples kept for each path parameter are sampled at
+	// random.
+	KeepRandomPathParamExampleValues bool
 }
 
 // Determines whether a given method has only 4xx response codes. Returns true if the method has at least one response and all response codes are 4xx.


### PR DESCRIPTION
Added support for obtaining a larger sample of path arguments, and choosing to have a random sample of them.

The `MeldDataIgnoreTracking` function has been removed. Not only was it was unused, it did not appear to be implemented. Both `MeldData` and `MeldDataIgnoreTracking` had identical behaviour.