### PR TITLE
Fix typos in method names

### DIFF
--- a/akid/akids.go
+++ b/akid/akids.go
@@ -768,11 +768,11 @@ func GenerateUsageTrackingEventID() UsageTrackingEventID {
 	return NewUsageTrackingEventID(uuid.New())
 }
 
-func (id UsageTrackingEventID) MarshallText() ([]byte, error) {
+func (id UsageTrackingEventID) MarshalText() ([]byte, error) {
 	return toText(id)
 }
 
-func (id UsageTrackingEventID) UnmarshallText(data []byte) error {
+func (id UsageTrackingEventID) UnmarshalText(data []byte) error {
 	return fromText(id, data)
 }
 
@@ -796,10 +796,10 @@ func NewPathParameterPrefixID(ID uuid.UUID) PathParameterPrefixID {
 	return PathParameterPrefixID{baseID(ID)}
 }
 
-func (id PathParameterPrefixID) MarshallText() ([]byte, error) {
+func (id PathParameterPrefixID) MarshalText() ([]byte, error) {
 	return toText(id)
 }
 
-func (id PathParameterPrefixID) UnmarshallText(data []byte) error {
+func (id PathParameterPrefixID) UnmarshalText(data []byte) error {
 	return fromText(id, data)
 }


### PR DESCRIPTION
Java has an `@Override` annotation just for this kind of bug.