### PR TITLE
Update akita-ir library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
+	github.com/akitasoftware/akita-ir v0.0.0-20231102193917-8b96486d4377 // todo: update this to match the commit on master once akita-ir#10 is merged
 	github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d
 	github.com/akitasoftware/objecthash-proto v0.0.0-20211020004800-9990a7ea5dc0
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
+github.com/akitasoftware/akita-ir v0.0.0-20231102193917-8b96486d4377 h1:AaUu5pd9GnOZptkkhoFrWJUivv+2+s/zmKHVOGItsrg=
+github.com/akitasoftware/akita-ir v0.0.0-20231102193917-8b96486d4377/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d h1:pN1dbNacZ/mvlU1NcJVDxqmKnrDQDTVaN6iKOarfdYM=
 github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/spec_util/ir_hash/gen/gen.go
+++ b/spec_util/ir_hash/gen/gen.go
@@ -112,6 +112,7 @@ func main() {
 	gf.AddHashFunc(reflect.TypeOf(pb.HTTPHeader{}))
 	gf.AddHashFunc(reflect.TypeOf(pb.HTTPMeta{}))
 	gf.AddHashFunc(reflect.TypeOf(pb.HTTPMethodMeta{}))
+	gf.AddHashFunc(reflect.TypeOf(pb.HTTPMethodError{}))
 	gf.AddHashFunc(reflect.TypeOf(pb.HTTPMultipart{}))
 	gf.AddHashFunc(reflect.TypeOf(pb.HTTPPath{}))
 	gf.AddHashFunc(reflect.TypeOf(pb.HTTPQuery{}))

--- a/spec_util/ir_hash/generated_types.go
+++ b/spec_util/ir_hash/generated_types.go
@@ -369,6 +369,19 @@ func HashHTTPMethodMeta(node *pb.HTTPMethodMeta) []byte {
 	}
 	return hash.Sum(nil)
 }
+func HashHTTPMethodError(node *pb.HTTPMethodError) []byte {
+	hash := xxhash.New64()
+	hash.Write([]byte("d"))
+	if node.Type != 0 {
+		hash.Write(intHashes[1])
+		hash.Write(Hash_Int32(int32(node.Type)))
+	}
+	if node.Message != "" {
+		hash.Write(intHashes[2])
+		hash.Write(Hash_Unicode(node.Message))
+	}
+	return hash.Sum(nil)
+}
 func HashHTTPMultipart(node *pb.HTTPMultipart) []byte {
 	hash := xxhash.New64()
 	hash.Write([]byte("d"))
@@ -620,6 +633,15 @@ func HashMethodMeta(node *pb.MethodMeta) []byte {
 	if val, ok := node.Meta.(*pb.MethodMeta_Http); ok {
 		hash.Write(intHashes[2])
 		hash.Write(HashHTTPMethodMeta(val.Http))
+	}
+	if len(node.Errors) != 0 {
+		hash.Write(intHashes[3])
+		listHash := xxhash.New64()
+		listHash.Write([]byte("l"))
+		for _, v := range node.Errors {
+			listHash.Write(HashHTTPMethodError(v))
+		}
+		hash.Write(listHash.Sum(nil))
 	}
 	return hash.Sum(nil)
 }
@@ -897,4 +919,4 @@ func HashWitness(node *pb.Witness) []byte {
 	return hash.Sum(nil)
 }
 
-var ProtobufFileHashes map[string][]byte = map[string][]byte{"method.proto": []byte{69, 16, 236, 176, 97, 180, 164, 70}, "witness.proto": []byte{42, 213, 185, 25, 124, 226, 76, 187}, "types.proto": []byte{98, 84, 34, 180, 249, 140, 214, 227}, "spec.proto": []byte{13, 101, 129, 126, 232, 252, 1, 146}}
+var ProtobufFileHashes map[string][]byte = map[string][]byte{"method.proto": []byte{171, 128, 95, 193, 109, 177, 168, 42}, "witness.proto": []byte{42, 213, 185, 25, 124, 226, 76, 187}, "types.proto": []byte{98, 84, 34, 180, 249, 140, 214, 227}, "spec.proto": []byte{13, 101, 129, 126, 232, 252, 1, 146}}


### PR DESCRIPTION
### Changes
This PR is built on top of https://github.com/akitasoftware/akita-ir/pull/10. 
- Here, we update the akita-ir version 
- In `akita-libs/spec_utils/ir_hash`, add the newly defined HTTPMethodMeta in `gen.go`
- Changes from running `make` in `akita-libs/spec_utils/ir_hash`

### TODO
Update akita-ir version to match the commit on master once [akita-ir#10](https://github.com/akitasoftware/akita-ir/pull/10) is merged