### PR TITLE
chore: convert analytic event property key to snake case

### DIFF
--- a/analytics/client.go
+++ b/analytics/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dukex/mixpanel"
 	"github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/iancoleman/strcase"
 	"github.com/pkg/errors"
 	segment "github.com/segmentio/analytics-go/v3"
 )
@@ -108,10 +109,16 @@ func (c clientImpl) TrackEvent(event *Event) error {
 			event.name = "Live Insights Agent - " + event.name
 		}
 
+		// Postman's property naming convention in Amplitude is snake case. So convert event.properties keys to snake case.
+		properties := map[string]any{}
+		for k, v := range event.properties {
+			properties[strcase.ToSnake(k)] = v
+		}
+
 		c.amplitudeClient.Track(amplitude.Event{
 			UserID:          event.distinctID,
 			EventType:       event.name,
-			EventProperties: event.properties,
+			EventProperties: properties,
 			EventOptions:    c.amplitudeAppInfo,
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/google/martian/v3 v3.0.1
 	github.com/google/uuid v1.3.0
+	github.com/iancoleman/strcase v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/exp v0.0.0-20220428152302-39d4317da171

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
According to the naming convention of our team in Amplitude, property keys should be in snake_case.

So have added a snippet to convert default camelCase to snake case before sending events to Amplitude.